### PR TITLE
Fixed Ecut/kTe naming standards

### DIFF
--- a/subroutines/continuum/get_norm_cont.f90
+++ b/subroutines/continuum/get_norm_cont.f90
@@ -1,8 +1,8 @@
 !-----------------------------------------------------------------------
-    function get_norm_cont(Gamma, Ecut_obs, logxi, logne)
+    function get_norm_cont(Gamma, Cutoff, logxi, logne)
       implicit none
 
-      real   , intent(IN) :: logxi, logne, Gamma, Ecut_obs
+      real   , intent(IN) :: logxi, logne, Gamma, Cutoff
       integer, parameter  :: nex = 1000
       real   , parameter  :: pi = acos(-1.0), ergsev  = 1.602197e-12 ! Convert eV to ergs
       integer             :: i, ifl
@@ -12,7 +12,7 @@
             
 !continuum paramters 
       nth_par(1) = Gamma
-      nth_par(2) = Ecut_obs
+      nth_par(2) = Cutoff
       nth_par(3) = 0.05d0
       nth_par(4) = 1.d0
       nth_par(5) = 0.d0

--- a/subroutines/continuum/getcont.f90
+++ b/subroutines/continuum/getcont.f90
@@ -1,21 +1,20 @@
 !-----------------------------------------------------------------------
-      subroutine getcont(Cp, earx, nex, Gamma, Ecut_obs, logxi, logne, contx)
+      subroutine getcont(Cp, earx, nex, Gamma, Cutoff, logxi, logne, contx)
 !!! Calculates continuum spectrum calling nthComp with the correct normalisation
 !!!based on the xillver spectrum 
 !!!  Arg:
         !  earx: energy grid
         !  nex: number of grid points
         !  Gamma: continuum spectrum inclination
-        !  Ecut_obs: high energy cut-off or electron temperature
+        !  Cutoff: high energy cut-off or electron temperature
         !  logxi: ionisation parameter
         !  logne: density 
-        !  (output) contx: continuum spectrum
-!!! Last change: Gullo 2023 Nov; adapted to match the xillver tables call 
+        !  (output) contx: continuum spectrum 
 
       use gr_continuum
       implicit none
       integer, intent(in)           :: nex, Cp
-      real   , intent(in)           :: earx(0:nex), Ecut_obs, logxi, logne
+      real   , intent(in)           :: earx(0:nex), Cutoff, logxi, logne
       real   , intent(out)          :: contx(nex)
       double precision , intent(in) :: Gamma
 
@@ -29,18 +28,15 @@
       if (Cp .eq. 2) then
 !So far this works only with kTe, so only with nthComp continuum model
          nth_par(1) = real(Gamma)
-         nth_par(2) = Ecut_obs
+         nth_par(2) = Cutoff
          nth_par(3) = 0.05
          nth_par(4) = 1.0
-         ! nth_par(5) = 0.0
          nth_par(5) = (1.0/ real(gso(1))) - 1.0
          Ifl=1
 
-      ! write(*,*) 'continuum parameters', nth_par
          call donthcomp(earx, nex, nth_par, ifl, contx, photer)
-!the continuum needs to be renormalised according to the illuminating flux that was considered in xillver 
-! Plus we divide by a factor that depends on ionisation and density to agree with the first versions of reltrans
-
+!The continuum needs to be renormalised according to the illuminating flux that was considered in xillver 
+!Plus we divide by a factor that depends on ionisation and density to agree with the first versions of reltrans
          do i = 1, nex
             E   = 0.5 * ( earx(i) + earx(i-1) )
             if (E .ge. 0.1 .and. E .le. 1e3) then
@@ -49,20 +45,11 @@
          enddo
          inc_flux = 10**(logne + logxi) / (4.0 * pi) / ergsev !calculate incident flux in units  [keV/cm^2/s]
          get_norm_cont_local = inc_flux/ Icomp / 1e20
-         
-         ! contx = contx * get_norm_cont(real(Gamma), Ecut_obs, logxi, logne)
-         ! contx = contx  / 10**(logxi + logne - 15)
          contx = contx * get_norm_cont_local / (10**(logxi + logne - 15))
-         ! write(*,*) 'continuum normalization parameters', get_norm_cont_local, logxi, logne
-
-      ! endif
-         
       else
-
-         ! write(*,*) 'continuum parameters ', Cp, Gamma, Ecut_obs
          do i = 1, nex
             E   = 0.5 * ( earx(i) + earx(i-1) )
-            contx(i) = E**(-1.0*real(Gamma)+1) * exp(-E/(Ecut_obs)) 
+            contx(i) = E**(-1.0*real(Gamma)+1) * exp(-E/(Cutoff)) 
             if (E .ge. 0.1 .and. E .le. 1e3) then
                Icomp = Icomp + ((earx(i) + earx(i-1)) * 0.5 * contx(i))
             endif
@@ -71,68 +58,7 @@
          get_norm_cont_local = inc_flux/ Icomp / 1e20
          contx = contx * get_norm_cont_local / (10**(logxi + logne - 15))
       endif
-      ! do i = 1, nex
-      !    write(20, *) (earx(i-1) + earx(i)) *0.5, contx(i)
-      ! enddo
-      ! write(20, *) 'no no'
          
       return
     end subroutine getcont
 !-----------------------------------------------------------------------
-
-
-! !-----------------------------------------------------------------------
-! subroutine getcont(nex,earx,Gamma,Ecut_obs,Cp,contx)
-!     !!! Calculates continuum spectrum and sets xillver parameters !!!
-!     !!!  Arg:
-!     !  earx: energy grid
-!     !  nex: number of grid points
-!     !  Gamma: continuum spectrum inclination
-!     !  Afe: iron abundance (not important for the continuum)
-!     !  Ecut_obs: high energy cut-off or electron temperature
-!     !  dens: log(density) of the disc
-!     !  logxi: ionisation parameter (not important for the continuum)
-!     !  Cp: sets which xillver spectrum
-!     ! (output) contx: continuum spectrum
-!     !!! Last change: Adam 2021 March; based on Gullo's getcont code from 2020 Jul
-!     !
-!     implicit none
-!     integer, intent(in)  :: nex, Cp
-!     real   , intent(in)  :: earx(0:nex), Ecut_obs
-!     real   , intent(out) :: contx(nex)
-!     real                 :: xillpar(7), xillparDCp(8)
-!     double precision , intent(in) :: Gamma
-!     integer :: ifl   
-!     !Set the parameters for the continuum and not only 
-
-!     !First determine which xillver and so which array of parameters 7 or 8
-!     ! Remember that only xillverDCp has 8 par all the others have 7 but with different interpretation of parameter 3 (xillver(3)) 
-!     !to clean up the code and not pass a million arguments we just take default values for ne/csi/theta/Afe, it does not impact
-!     !the continuum anyway 
-!     if (Cp .eq. 2) then
-!         xillparDCp(1) = real( Gamma )
-!         xillparDCp(2) = 1.
-!         xillparDCp(3) = Ecut_obs
-!         xillparDCp(4) = 15.
-!         xillparDCp(5) = 0.0
-!         xillparDCp(6) = 0.0   
-!         xillparDCp(7) = 30.0 
-!         xillparDCp(8) = 0.0       !reflection fraction of 0
-!     else if (Cp .lt. 0 ) then
-!         xillpar(3) = Ecut_obs
-!     else if (Cp .eq. 1) then
-!         xillpar(3) = 15.
-!     endif
-
-!     xillpar(1) = real( Gamma )
-!     xillpar(2) = 1.
-!     xillpar(4) = 0.
-!     xillpar(5) = 0.0   !cosmological redshift is accounted for by the transfer function
-!     xillpar(6) = 30.0       !inclination angle (doesn't matter for continuum)
-!     xillpar(7) = 0.0       !reflection fraction of 0
-!     ifl        = 1
-
-!     call get_xillver(earx,nex,xillpar,xillparDCp,ifl,Cp,contx)
-!     return
-! end subroutine getcont
-! !-----------------------------------------------------------------------

--- a/subroutines/continuum/init_cont.f90
+++ b/subroutines/continuum/init_cont.f90
@@ -1,4 +1,4 @@
-subroutine init_cont(nlp, a, h, zcos, Ecut_s, Ecut_obs, logxi, logne, &
+subroutine init_cont(nlp, a, h, zcos, Cutoff_s, Cutoff_obs, logxi, logne, &
      muobs, Cp_cont, Cp, fcons, Gamma, Dkpc, Mass,&
     earx, Emin, Emax, contx, dlogE, verbose, dset, Anorm, contx_int, eta)
     !!!sets up the continuum arrays/quantities depending on model parameters/flavour 
@@ -15,20 +15,18 @@ subroutine init_cont(nlp, a, h, zcos, Ecut_s, Ecut_obs, logxi, logne, &
     double precision, intent(out)   :: fcons,contx_int(nlp)
     
     integer                         :: m, i
-    real                            :: Ecut_s,Ecut_obs,Eintegrate
+    real                            :: Cutoff_s,Cutoff_obs,Eintegrate
     double precision                :: lacc,ell13pt6,get_lacc,get_fcons,dgsofac
 
     
     if (nlp .eq. 1) then 
-
        ! gso(1) = real( dgsofac(a,h(1)) ) 
        ! call getlens(a,h(1),muobs,lens(1),tauso(1),cosdelta_obs(1))
-       ! if( tauso(1) .ne. tauso(1) ) stop "tauso is NaN"
-       
-       Ecut_s = real(1.d0+zcos) * Ecut_obs / gso(1)
+       ! if( tauso(1) .ne. tauso(1) ) stop "tauso is NaN"       
+       Cutoff_s = real(1.d0+zcos) * Cutoff_obs / gso(1)
        Cp_cont = Cp
        if( Cp .eq. 0 ) Cp_cont = 2 !For reflection given by reflionx
-       call getcont(Cp, earx, nex, Gamma, Ecut_obs, logxi, logne, contx(:,1))
+       call getcont(Cp, earx, nex, Gamma, Cutoff_obs, logxi, logne, contx(:,1))
        
        if( dset .eq. 1 ) then
           fcons = get_fcons(h(1),a,zcos,Gamma,Dkpc,Mass,Anorm,nex,earx,contx,dlogE)     
@@ -46,9 +44,9 @@ subroutine init_cont(nlp, a, h, zcos, Ecut_s, Ecut_obs, logxi, logne, &
              call sourcelum(nex,earx,contx,real(Mass),real(gso(1)),real(Gamma))
           end if
           if( abs(Cp) .eq. 1 )then
-             write(*,*)"Ecut in source restframe (keV)=",Ecut_s
+             write(*,*)"Ecut in source restframe (keV)=",Cutoff_s
           else
-             write(*,*)"kTe in source restframe (keV)=", Ecut_s
+             write(*,*)"kTe in source restframe (keV)=", Cutoff_s
           end if
           write(*,*) 'gso factor ', gso(1)
           write(*,*) 'lensing factor ', lens(1)
@@ -72,24 +70,21 @@ subroutine init_cont(nlp, a, h, zcos, Ecut_s, Ecut_obs, logxi, logne, &
           ! gso(m) = real( dgsofac(a,h(m)) )
           ! call getlens(a,h(m),muobs,lens(m),tauso(m),cosdelta_obs(m))
           ! if( tauso(m) .ne. tauso(m) ) stop "tauso is NaN"
-
-          Ecut_obs = Ecut_s * gso(m) / real(1.d0+zcos)
+          Cutoff_obs = Cutoff_s * gso(m) / real(1.d0+zcos)
           Cp_cont = Cp 
           if( Cp .eq. 0 ) Cp_cont = 2 !For reflection given by reflionx        
-          call getcont(Cp, earx, nex, Gamma, Ecut_obs, logxi, logne, contx(:,m))
+          call getcont(Cp, earx, nex, Gamma, Cutoff_obs, logxi, logne, contx(:,m))
           if (m .gt. 1) contx(:,m) = eta*contx(:,m)  
           !TODO fix this section, calculate luminosities better
           if( verbose .gt. 0 )then
              call sourcelum(nex,earx,contx(:,m),real(mass),real(gso(m)),real(Gamma))
              if( abs(Cp) .eq. 1 )then
-                write(*,*)"Ecut observed from source #", m, "is (keV)=" ,Ecut_obs
+                write(*,*)"Ecut observed from source #", m, "is (keV)=" ,Cutoff_obs
              else
-                write(*,*)"kTe observed from source #", m, "is (keV)=" ,Ecut_obs
+                write(*,*)"kTe observed from source #", m, "is (keV)=" ,Cutoff_obs
              end if
           end if
           contx_int(m) = Eintegrate(Emin,Emax,nex,earx,contx(:,m),dlogE)    
-
-          ! contx(:,m) = lens(m) * (gso(m)/(real(1.d0+zcos)))**Gamma * contx(:,m)
           if (Cp .eq. 2) then
              contx = lens(1) * (gso(1)/(real(1.d0+zcos))) * contx
           else
@@ -97,6 +92,5 @@ subroutine init_cont(nlp, a, h, zcos, Ecut_s, Ecut_obs, logxi, logne, &
           endif
        end do
     end if  
-    !TBD ADD PROPAGATION LAG HERE
 
 end subroutine init_cont

--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -45,7 +45,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
     double precision :: d
     !Parameters of the model:
     double precision :: h(nlp), a, inc, rin, rout, zcos, Gamma, honr, muobs 
-    real             :: logxi, Afe, lognep, Ecut_obs, Ecut_s, Dkpc, Anorm, beta_p
+    real             :: logxi, Afe, lognep, Cutoff_obs, Cutoff_s, Dkpc, Anorm, beta_p
     real             :: Nh, boost, Mass, floHz, fhiHz, DelA, DelAB(nlp), g(nlp)
     integer          :: ReIm, resp_matr
     double precision :: qboost,b1,b2, eta, eta_0
@@ -93,7 +93,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
     double precision :: disco, dgsofac
     ! New  
     double precision :: fcons,get_fcons,contx_temp!,ell13pt6,lacc,get_lacc,
-    real             :: Gamma0,logne,Ecut0,thetae,logxi1, logxi2
+    real             :: Gamma0,logne,Cutoff_0,thetae,logxi1, logxi2
     integer          :: Cp_cont
     real time_start,time_end        !runtime stuff
     integer env_test
@@ -122,11 +122,11 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
     !Note: the two different calls are because for the double lP we set the temperature from the coronal frame(s), but for the single
     !LP we use the temperature in the observer frame
     if (nlp .eq. 1) then
-        call set_param(Cp,dset,param,nlp,h,a,inc,rin,rout,zcos,Gamma,logxi,Dkpc,Afe,lognep,Ecut_obs,&
+        call set_param(Cp,dset,param,nlp,h,a,inc,rin,rout,zcos,Gamma,logxi,Dkpc,Afe,lognep,Cutoff_obs,&
                        eta_0,eta,beta_p,Nh,boost,qboost,Mass,honr,b1,b2,floHz,fhiHz,ReIm,DelA,DelAB,&
                        g,Anorm,resp_matr,refvar,verbose)        
     else 
-        call set_param(Cp,dset,param,nlp,h,a,inc,rin,rout,zcos,Gamma,logxi,Dkpc,Afe,lognep,Ecut_s,&
+        call set_param(Cp,dset,param,nlp,h,a,inc,rin,rout,zcos,Gamma,logxi,Dkpc,Afe,lognep,Cutoff_s,&
                        eta_0,eta,beta_p,Nh,boost,qboost,Mass,honr,b1,b2,floHz,fhiHz,ReIm,DelA,DelAB,&
                        g,Anorm,resp_matr,refvar,verbose) 
     end if 
@@ -277,7 +277,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
     !We need to call the continuum BEFORE the radial profiles in the rest of the flavuors
     if( dset .eq. 0 .or. size(h) .eq. 2) then
        !set up the continuum spectrum plus relative quantities (cutoff energies, lensing/gfactors, luminosity, etc)
-       call init_cont(nlp,a,h,zcos,Ecut_s,Ecut_obs,logxi, lognep, muobs,Cp_cont,Cp,fcons,Gamma,&
+       call init_cont(nlp,a,h,zcos,Cutoff_s,Cutoff_obs,logxi, lognep, muobs,Cp_cont,Cp,fcons,Gamma,&
                    Dkpc,Mass,earx,Emin,Emax,contx,dlogE,verbose,dset,Anorm,contx_int,eta)
 
        call radfunctions_dens(verbose,xe,rin,rnmax,eta_0,dble(logxi),dble(lognep),a,h,Gamma,honr,&
@@ -288,7 +288,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
                            & logxir,gsdr,logner,pnorm)
         !set up the continuum spectrum plus relative quantities (cutoff energies, lensing/gfactors, luminosity, etc)
         logxi = logxir(1)
-        call init_cont(nlp,a,h,zcos,Ecut_s,Ecut_obs,logxi, lognep,muobs,Cp_cont,Cp,fcons,Gamma,&
+        call init_cont(nlp,a,h,zcos,Cutoff_s,Cutoff_obs,logxi, lognep,muobs,Cp_cont,Cp,fcons,Gamma,&
                    Dkpc,Mass,earx,Emin,Emax,contx,dlogE,verbose,dset,Anorm,contx_int,eta)
 
      end if
@@ -327,10 +327,10 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
             !Set parameters with radial dependence
             Gamma0 = real(Gamma)
             logne  = logner(rbin)
-            Ecut0  = real( gsdr(rbin) ) * Ecut_s
+            Cutoff_0  = real( gsdr(rbin) ) * Cutoff_s
             logxi0 = real( logxir(rbin) )
             if( xe .eq. 1 )then
-                Ecut0  = Ecut_s
+                Cutoff_0  = Cutoff_s
                 logne  = lognep
                 logxi0 = logxi
             end if
@@ -344,18 +344,18 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
                 thetae = acos( mue ) * 180.0 / real(pi)
                 if( me .eq. 1 ) thetae = real(inc)
                 !Call restframe reflection model
-                call rest_frame(earx,nex,Gamma0,Afe,logne,Ecut0,logxi0,thetae,Cp,photarx)
+                call rest_frame(earx,nex,Gamma0,Afe,logne,Cutoff_0,logxi0,thetae,Cp,photarx)
                 !NON LINEAR EFFECTS
                 if (DC .eq. 0) then 
                    !Gamma variations
                    logxi1 = logxi0 + ionvariation * dlogxi1
-                   call rest_frame(earx,nex,Gamma1,Afe,logne,Ecut0,logxi1,thetae,Cp,photarx_1)
+                   call rest_frame(earx,nex,Gamma1,Afe,logne,Cutoff_0,logxi1,thetae,Cp,photarx_1)
                    logxi2 = logxi0 + ionvariation * dlogxi2
-                   call rest_frame(earx,nex,Gamma2,Afe,logne,Ecut0,logxi2,thetae,Cp,photarx_2)
+                   call rest_frame(earx,nex,Gamma2,Afe,logne,Cutoff_0,logxi2,thetae,Cp,photarx_2)
                    photarx_delta = (photarx_2 - photarx_1)/(Gamma2-Gamma1)
                    !xi variations
-                   call rest_frame(earx,nex,Gamma0,Afe,logne,Ecut0,logxi1,thetae,Cp,photarx_1)
-                   call rest_frame(earx,nex,Gamma0,Afe,logne,Ecut0,logxi2,thetae,Cp,photarx_2)
+                   call rest_frame(earx,nex,Gamma0,Afe,logne,Cutoff_0,logxi1,thetae,Cp,photarx_1)
+                   call rest_frame(earx,nex,Gamma0,Afe,logne,Cutoff_0,logxi2,thetae,Cp,photarx_2)
                    photarx_dlogxi = 0.434294481 * (photarx_2 - photarx_1) / (dlogxi2-dlogxi1) !pre-factor is 1/ln10
                 end if
                 !Loop through frequencies and lamp posts
@@ -372,12 +372,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
                             imline_w3(m,i) = aimag( ker_W3(m,i,j,mubin,rbin) )
                         end do  
                     end do
-                    !always: convolution for reverberation/DC spectrum
-                    !TBD: add flag here to do this convolution if no reflection time, or different convolution with complex
-                    !xillver if tref > 0 or something.                    
-
                     if (test) then
-                       
                        call conv_one_FFT(dyn,photarx,reline_w0,imline_w0,ReW0(:,:,j),ImW0(:,:,j),DC,nlp)
                        if(DC .eq. 0 .and. refvar .eq. 1) then
                           call conv_one_FFT(dyn,photarx,reline_w1,imline_w1,ReW1(:,:,j),ImW1(:,:,j),DC,nlp)
@@ -397,10 +392,6 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
                           call conv_one_FFTw(dyn,photarx_dlogxi,reline_w3,imline_w3,ReW3(:,:,j),ImW3(:,:,j),DC,nlp)
                        end if
                     endif                    
-                    !old call: always convolve every single transfer function in one go
-                    !call conv_all_FFTw(dyn,photarx,photarx_delta,photarx_dlogxi,reline_w0,imline_w0,reline_w1,imline_w1,&
-                    !     reline_w2,imline_w2,reline_w3,imline_w3,ReW0(:,:,j),ImW0(:,:,j),ReW1(:,:,j),ImW1(:,:,j),&
-                    !     ReW2(:,:,j),ImW2(:,:,j),ReW3(:,:,j),ImW3(:,:,j),DC,nlp)
                  end do
             end do
         end do

--- a/subroutines/rest_frame_reflection/get_xillver.f90
+++ b/subroutines/rest_frame_reflection/get_xillver.f90
@@ -25,14 +25,10 @@
 
       ifl = 0
       if( Cp .eq. -1 )then         !xillver
-         ! write(*,*) 'xillverPL parameters', param_xillPL
          call xsatbl(ear, ne, param_xillPL, trim(pathname_xillver), ifl, photar, photer)
       else if( Cp .eq. 1 )then     !xillverD
-         ! write(*,*) 'xillverD parameters', param_xillPL
-         ! write(*,*) trim(pathname_xillverD)
          call xsatbl(ear, ne, param_xillPL, trim(pathname_xillverD), ifl, photar, photer)
       else if ( Cp .eq. 2 )then    !xillverDCp
-         ! write(*,*) 'xillverCp parameters', param_xillCp
          call xsatbl(ear, ne, param_xillCp, trim(pathname_xillverDCp), ifl, photar, photer)
       else
          write(*,*) 'No xillver model available for this configuration'

--- a/subroutines/rest_frame_reflection/normreflionx.f90
+++ b/subroutines/rest_frame_reflection/normreflionx.f90
@@ -39,7 +39,7 @@ subroutine normreflionx(ear,ne,Gamma,Afe,logne,kTe,logxi,thetae,photar)
   xillparDCp(1) = Gamma  !photon index
   xillparDCp(2) = Afe    !Afe
   xillparDCp(3) = logxi  !ionization par
-  xillparDCp(4) = kTe    !Ecut or kTe
+  xillparDCp(4) = kTe    !kTe
   lognex = logne
   lognex = min(logne,20.0)
   lognex = max(logne,15.0)

--- a/subroutines/rest_frame_reflection/rest_frame.f90
+++ b/subroutines/rest_frame_reflection/rest_frame.f90
@@ -1,5 +1,5 @@
 !-----------------------------------------------------------------------
-subroutine rest_frame(ear,ne,Gamma,Afe,logne,Ecut,logxi,thetae,Cp,photar)
+subroutine rest_frame(ear,ne,Gamma,Afe,logne,Cutoff,logxi,thetae,Cp,photar)
 !
 !  Cp : chooses reflection model
 !      -1 xillver      1e15 density and powerlaw illumination  
@@ -8,15 +8,16 @@ subroutine rest_frame(ear,ne,Gamma,Afe,logne,Ecut,logxi,thetae,Cp,photar)
 !       0 reflionxDCp  reflionx high density and nthcomp  illumination
 !
 !       The first 2 have the same number of parameters xillpar(6), 
-!       in the first one the Ecut is a parameter and the density is fixed to 10^15
-!       in the second one the density is a parameter and Ecut is fixed to 300 keV 
-!       The Cp = 2 has one more parameter both Ecut and density are parameters
+!       in the first one Cutoff is a parameter (either energy or temperature)
+!       and the density is fixed to 10^15
+!       in the second one the density is a parameter and Cutoff is fixed to 300 keV 
+!       The Cp = 2 has one more parameter both Cutoff and density are parameters
 
 !       Last change: Gullo - 2022 Oct
 
    implicit none
    integer, intent(in) :: ne, Cp
-   real, intent(in)    :: ear(0:ne), Gamma, Afe, logne, Ecut, logxi, thetae
+   real, intent(in)    :: ear(0:ne), Gamma, Afe, logne, Cutoff, logxi, thetae
    real, intent(out)   :: photar(ne)
    integer, parameter  :: dim = 6, dimCp = 8
    real                :: xillpar(dim), xillparDCp(dimCp)
@@ -30,7 +31,7 @@ subroutine rest_frame(ear,ne,Gamma,Afe,logne,Ecut,logxi,thetae,Cp,photar)
       xillpar(1) = Gamma     !Power law index
       xillpar(2) = Afe       !Iron abundance
       xillpar(3) = logxi     !ionization par
-      xillpar(4) = Ecut      !Ecut or kTe
+      xillpar(4) = Cutoff      !Ecut or kTe
       if( Cp .eq. 1 )then
          xillpar(4) = logne !logne
       end if
@@ -39,7 +40,7 @@ subroutine rest_frame(ear,ne,Gamma,Afe,logne,Ecut,logxi,thetae,Cp,photar)
       xillparDCp(1) = Gamma  !photon index
       xillparDCp(2) = Afe    !Afe
       xillparDCp(3) = logxi  !ionization par
-      xillparDCp(4) = Ecut   !kTe
+      xillparDCp(4) = Cutoff   !kTe
       xillparDCp(5) = logne !logne
       xillparDCp(6) = thetae !emission angle
       xillparDCp(7) = 0.0  !redshift !this parameters was here when we called relxill to get xillver
@@ -54,7 +55,7 @@ subroutine rest_frame(ear,ne,Gamma,Afe,logne,Ecut,logxi,thetae,Cp,photar)
       !The model is reflionx
       !Set density limits
    !   lognex = min(logne,22.0)
-      call normreflionx(ear,ne,Gamma,Afe,logne,Ecut,logxi,thetae,photar)
+      call normreflionx(ear,ne,Gamma,Afe,logne,Cutoff,logxi,thetae,photar)
    end if
 
    return

--- a/subroutines/set_param.f90
+++ b/subroutines/set_param.f90
@@ -1,4 +1,4 @@
-subroutine set_param(Cp,dset,param,nlp,h,a,inc,rin,rout,zcos,Gamma,logxi,Dkpc,Afe,lognep,Ecut,&
+subroutine set_param(Cp,dset,param,nlp,h,a,inc,rin,rout,zcos,Gamma,logxi,Dkpc,Afe,lognep,Cutoff,&
                      eta_0,eta,beta_p,Nh,boost,qboost,Mass,honr,b1,b2,floHz,fhiHz,ReIm,DelA,DelAB,&
                      g,Anorm,resp,refvar,verbose)
 !!! Sets the parameters of reltrans depending on the Cp variable
@@ -7,7 +7,7 @@ subroutine set_param(Cp,dset,param,nlp,h,a,inc,rin,rout,zcos,Gamma,logxi,Dkpc,Af
   real            , intent(in)   :: param(32)
   double precision, intent(out)  :: h(nlp), a, inc, rin, rout, zcos, Gamma
   double precision, intent(out)  :: honr, b1, b2, qboost, eta_0, eta
-  real            , intent(out)  :: logxi, Afe, lognep, Ecut, beta_p
+  real            , intent(out)  :: logxi, Afe, lognep, Cutoff, beta_p
   real            , intent(out)  :: Nh, boost, Mass, floHz, fhiHz
   real            , intent(out)  :: DelA, DelAB(nlp), g(nlp), Anorm, Dkpc
   integer         , intent(out)  :: ReIm, resp, refvar
@@ -28,16 +28,11 @@ subroutine set_param(Cp,dset,param,nlp,h,a,inc,rin,rout,zcos,Gamma,logxi,Dkpc,Af
   Afe      = param(10)
   lognep   = param(11)
   if (Cp .eq. 1) then 
-     Ecut = 300.0
+     Cutoff = 300.0
   else
-     Ecut     = param(12) !This is the corona frame temperature for the double LP model, and the observed one otherwise
+     Cutoff = param(12) !This is the corona frame temperature for the double LP model, and the observed one otherwise
   endif
-  !if(nlp .gt. 1 .and. param(13) .eq. 0) then
-  !    eta_0 = 1.e-4
-  !    if (verbose .gt. 0) print*,"WARNING: low eta_0 for double LP, careful with pivoting!!!"
-  !else
   eta_0    = param(13)
-  !end if  
   eta      = param(14)
   beta_p   = param(15)
   Nh       = param(16)
@@ -63,12 +58,6 @@ subroutine set_param(Cp,dset,param,nlp,h,a,inc,rin,rout,zcos,Gamma,logxi,Dkpc,Af
   else
      Dkpc = 0.0
   end if
-  
-  !WIP optimization, need to think how best to handle this for cases when phiab/g change
-  !but we don't want to re-do all the convolutions
- ! if(all(g .eq. 0 ) .or. all(DelAB .eq. 0)) then
- !    refvar = 0  
- ! end if
 
   return
 end subroutine set_param


### PR DESCRIPTION
All quantities relevant to the cutoff in the continuum are now named Cutoff, to generalize the distinction between Ecut (for a powerlaw model) and nthcomp (for a comptonization model). The only exception to this in normreflionx, since that model only takes input temperature anyway. 

Solves issue #17.