### PR TITLE
Add more options in the config script

### DIFF
--- a/renormalise_table.py
+++ b/renormalise_table.py
@@ -3,7 +3,7 @@ from astropy.io import fits
 import os
 import sys
 ########################################################################
-def query_yes_no(question, default="yes"):
+def query_yes_no(question, default="no"):
     """Ask a yes/no question via raw_input() and return their answer.
 
     "question" is a string that is presented to the user.
@@ -35,10 +35,32 @@ def query_yes_no(question, default="yes"):
             sys.stdout.write("Please respond with 'yes' or 'no' "
                              "(or 'y' or 'n').\n")
 ########################################################################
+xillver_table_name = ['xillverCp_v3.4.fits', 'xillver-a-Ec5.fits']
 
+if (query_yes_no('Have you set the environment variable RELTRANS_TABLES?')):
+    reltrans_table = os.environ['RELTRANS_TABLES']
+    print(f'The RELTRANS_TABLES env variable is {reltrans_table}')
+    print
+else:
+    # print('Indicate the path of the folder where either you keep the xillver tables or you want to download them')
+    reltrans_table = input('Indicate the path of the folder where either you keep the xillver tables or you want to download them: ')
+    print(reltrans_table)
+    print
+    
+print()
+print(f'The first part of the script gives the option to download the xillver tables')
+print(f'(reltrans needs the xillver tables: {xillver_table_name[0]} and {xillver_table_name[1]})')
+print()
+if (query_yes_no('Do you need to download the xillver tables?')):
+    command = 'wget -c --retry-connrefused --waitretry=5 --timeout=30 -t 10 -P ' + str(reltrans_table) + ' https://sites.srl.caltech.edu/~javier/xillver/tables/'
 
-reltrans_table = os.environ['RELTRANS_TABLES']
-xillver_table_name = ['xillverCp_v3.4.fits', 'xillver-a-Ec5.fits', 'xillverD-5.fits']
+    for name_table in xillver_table_name:
+        print
+        command_temp = command + name_table
+        print(command_temp)
+        os.system(command_temp)
+        print
+
 
 print()
 print('This script is going to create new version of the xillver tables')


### PR DESCRIPTION
Updates to the config script: 
- it asks if the user has set the env variable RELTRANS_TABLES, if not it gives the possibility to set it on the fly 
- it asks the user if they want to download the xillver tables needed by reltrans
- Default answer to renormalise the xillver table is no
The last two points solve #26 and #43 