### PR TITLE
Add structured steady-state profiler and performance guide

### DIFF
--- a/docs/performance_profiling.md
+++ b/docs/performance_profiling.md
@@ -1,0 +1,21 @@
+# Performance Profiling Guide
+
+This document describes how to profile reltrans model evaluations in a
+structured and reproducible way.
+
+## Why steady-state profiling?
+
+The first call to `rt.dcp()` may include FFTW initialization overhead.
+To measure realistic runtime performance, we:
+
+1. Perform one warmup evaluation.
+2. Profile only subsequent evaluations.
+3. Focus on cumulative time (`cumtime`) to identify bottlenecks.
+
+## Running the profiler
+
+From the project root:
+
+```bash
+python profiling/profile_dcp.py
+

--- a/profiling/profile_dcp.py
+++ b/profiling/profile_dcp.py
@@ -1,0 +1,57 @@
+"""
+Structured profiling script for reltrans DCP evaluation.
+
+This script focuses on steady-state performance by ignoring the first
+evaluation (which may include FFTW initialization cost).
+"""
+
+import sys
+import pathlib
+import cProfile
+import pstats
+import io
+import numpy as np
+
+# Add project root to path
+project_root = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(project_root))
+
+from test.wrapper import Reltrans, DCP_Parameters
+
+
+def run_profile(n_runs=5):
+    energy = np.logspace(-1, 2, 400).astype(np.float32)
+    params = DCP_Parameters()
+
+    try:
+        rt = Reltrans()
+    except RuntimeError as e:
+        print("Native library not available.")
+        print("Please build reltrans and ensure HEASoft is configured.")
+        sys.exit(1)
+
+    # Warmup (ignore FFTW initialization overhead)
+    print("Running warmup evaluation...")
+    rt.dcp(energy, params)
+
+    print(f"Profiling steady-state over {n_runs} runs...")
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+
+    for _ in range(n_runs):
+        rt.dcp(energy, params)
+
+    profiler.disable()
+
+    s = io.StringIO()
+    stats = pstats.Stats(profiler, stream=s).sort_stats("cumtime")
+    stats.print_stats(20)
+
+    print("\nTop 20 functions by cumulative time:\n")
+    print(s.getvalue())
+
+
+if __name__ == "__main__":
+    run_profile()
+


### PR DESCRIPTION
This PR introduces a structured profiling setup focused on steady-state
performance of the DCP model evaluation.

Background:
The first evaluation of the model is typically slower due to FFTW
initialization and setup overhead. For fitting purposes, the steady-state
runtime (after the first call) is more relevant.

Changes:
- Add profiling/profile_dcp.py for controlled steady-state profiling
- Add performance profiling documentation under docs/
- Clearly separate first-run vs repeated-run timing
- Provide reproducible workflow for future optimization work

This aims to:
- Establish a consistent profiling baseline
- Make future optimization efforts data-driven
- Reduce ambiguity when measuring performance improvements
