### PR TITLE
refactor: use RuntimeError instead of generic Exception in test wrapper

### DIFF
--- a/test/wrapper.py
+++ b/test/wrapper.py
@@ -35,7 +35,7 @@ def get_reltrans_library_path(lib_name="libreltrans") -> str:
     elif system == "Darwin":
         lib_name = lib_name + ".dylib"
     else:
-        raise Exception("Unsupported OS " + system)
+        raise RuntimeError(f"Unsupported OS: {system}")
 
     lib_path = build_dir / lib_name
     print(str(lib_path.absolute()))


### PR DESCRIPTION
Replaces a generic Exception with RuntimeError in test/wrapper.py when an unsupported OS is detected. This makes the raised error more specific while preserving existing behavior.