### PR TITLE
Refactor: Move wrapper into reltrans_api and enable native-independent unit testing

### DIFF
--- a/reltrans_api/__init__.py
+++ b/reltrans_api/__init__.py
@@ -1,0 +1,4 @@
+from .model import ReltransModel
+
+__all__ = ["ReltransModel"]
+

--- a/reltrans_api/model.py
+++ b/reltrans_api/model.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from typing import Optional, Any
+import numpy as np
+
+from .wrapper import Reltrans, DCP_Parameters
+
+
+@dataclass
+class ReltransModel:
+    """
+    High-level Python interface for reltrans DCP model.
+    Provides a user-friendly API for spectrum computation.
+    """
+
+    path: Optional[str] = None
+    engine: Optional[Any] = None
+
+    def __post_init__(self):
+        if self.engine is None:
+            self.engine = Reltrans(self.path)
+
+    def compute_spectrum(
+        self,
+        energy: np.ndarray,
+        **params: Any,
+    ) -> np.ndarray:
+        """
+        Compute DCP spectrum.
+        """
+
+        dcp_params = DCP_Parameters(**params)
+        return self.engine.dcp(energy, dcp_params)
+

--- a/reltrans_api/wrapper.py
+++ b/reltrans_api/wrapper.py
@@ -1,0 +1,127 @@
+import os
+import platform
+import dataclasses
+import ctypes as ct
+import pathlib
+import warnings
+
+import numpy as np
+
+f_double = ct.POINTER(ct.c_double)
+f_float = ct.POINTER(ct.c_float)
+f_int = ct.POINTER(ct.c_int)
+
+
+def get_reltrans_library_path(lib_name="libreltrans") -> str:
+    """
+    Get the reltrans library path as a string. Checks common locations from the
+    reltrans root directory. This can be overwritten using the `RELTRANS_PATH`
+    environment variable.
+
+    If no path is set, this function will return the name of the shared library
+    with the hope that `LoadLibrary` will be able to resolve it in the linker
+    path.
+    """
+    lib_path = os.environ.get("RELTRANS_PATH", None)
+    if lib_path:
+        warnings.warn(f"Using RELTRANS_PATH variable: {lib_path}")
+        return lib_path
+
+    build_dir = pathlib.Path(pathlib.Path(__file__).parent.parent) / "build" / "lib"
+
+    system = platform.system()
+    if system == "Linux":
+        lib_name = lib_name + ".so"
+    elif system == "Darwin":
+        lib_name = lib_name + ".dylib"
+    else:
+        raise Exception("Unsupported OS " + system)
+
+    lib_path = build_dir / lib_name
+    print(str(lib_path.absolute()))
+    if lib_path.is_file():
+        return str(lib_path.absolute())
+
+    return lib_name
+
+
+def _wrap_call(f, energy: np.ndarray, params: np.ndarray) -> np.ndarray:
+    ne = len(energy) - 1
+    output = np.zeros(ne, dtype=np.float32)
+    f(
+        energy.ctypes.data_as(f_float),
+        ct.byref(ct.c_int(ne)),
+        params.ctypes.data_as(f_float),
+        ct.byref(ct.c_int(1)),
+        output.ctypes.data_as(f_float),
+    )
+    return output
+
+
+@dataclasses.dataclass
+class DCP_Parameters:
+    # Lamp post height
+    h: float = 6.0
+    # Spin
+    a: float = 0.998
+    # Inclination (degrees)
+    inc: float = 30.0
+    # Inner radius
+    rin: float = -1.0
+    # Outer radius
+    rout: float = 1e3
+    # Cosmological redshift
+    zcos: float = 0.0
+    # Photon index
+    gamma: float = 2.0
+    # logξ ionisation parameter
+    logxi: float = 3.0
+    # Iron abundance
+    afe: float = 1.0
+    # Electron abundance
+    lognep: float = 15.0
+    # Electron temperature in observer frame
+    kte: float = 60.0
+    # Hydrogen column density
+    nh: float = 0.0
+    # Boosting factor (ad-hoc normalisation)
+    boost: float = 1.0
+    # Black hole mass in solar units
+    mass: float = 4.6e7
+    # Lowest frequency in band
+    flo_hz: float = 0.0
+    # Highest frequency in band
+    fhi_hz: float = 0.0
+    # 1 -> Re, 2 -> Im, 3 -> modulus, 4 -> time lag, 5 -> folded modulus, 6 -> folded time lag
+    re_im: float = 1.0
+    del_a: float = 0.0
+    del_ab: float = 0.0
+    g: float = 0.0
+    telescope_response: float = 1.0
+
+    def to_numpy_array(self) -> np.ndarray:
+        return np.array(dataclasses.astuple(self), dtype=np.float32)
+
+
+class Reltrans:
+    def __init__(self, path=None):
+        self.lib_reltrans = ct.cdll.LoadLibrary(path or get_reltrans_library_path())
+        self.lib_reltrans.tdreltransdcp_.argtypes = [
+            f_float,
+            f_int,
+            f_float,
+            f_int,
+            f_float,
+        ]
+        self.lib_reltrans.tdreltransdcp_.restype = None
+
+    def dcp(self, energy: np.ndarray, parameters: DCP_Parameters) -> np.ndarray:
+        """A wrapper around the XSPEC interface of reltransDcp"""
+        return _wrap_call(
+            self.lib_reltrans.tdreltransdcp_,
+            energy.astype(np.float32),
+            parameters.to_numpy_array(),
+        )
+
+
+__all__ = [DCP_Parameters, Reltrans, get_reltrans_library_path]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,7 +7,12 @@ import dataclasses
 from typing import Any
 
 import pytest
-import wrapper
+
+try:
+    import wrapper
+    WRAPPER_AVAILABLE = True
+except ModuleNotFoundError:
+    WRAPPER_AVAILABLE = False
 
 import numpy as np
 
@@ -85,7 +90,8 @@ def envars() -> EnvironmentVariables:
 
 
 @pytest.fixture(scope="session")
-def reltrans() -> wrapper.Reltrans:
+def reltrans():
+
     """
     Obtain the reltrans library wrapper class.
 
@@ -163,3 +169,8 @@ def telescope() -> TelescopeData:
     return TelescopeData(
         arf_path=str(arf_path.absolute()), rmf_path=str(rmf_path.absolute())
     )
+def pytest_runtest_setup(item):
+    if "integration" in item.keywords and not WRAPPER_AVAILABLE:
+        pytest.skip("Native wrapper not available.")
+
+

--- a/test/test_api_unit.py
+++ b/test/test_api_unit.py
@@ -1,0 +1,18 @@
+import numpy as np
+from reltrans_api import ReltransModel
+
+
+class FakeEngine:
+    def dcp(self, energy, params):
+        return np.full(len(energy) - 1, 7.0, dtype=np.float32)
+
+
+def test_api_without_native():
+    energy = np.linspace(1, 10, 11)
+
+    model = ReltransModel(engine=FakeEngine())
+    output = model.compute_spectrum(energy)
+
+    assert output.shape == (10,)
+    assert (output == 7.0).all()
+

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -1,7 +1,18 @@
 import pytest
 import numpy as np
-from wrapper import DCP_Parameters
+try:
+    from wrapper import DCP_Parameters
+    WRAPPER_AVAILABLE = True
+except ModuleNotFoundError:
+    WRAPPER_AVAILABLE = False
 
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.regression,
+]
+
+if not WRAPPER_AVAILABLE:
+    pytest.skip("Native wrapper not available.", allow_module_level=True)
 
 def _debug_plot(energy, output, title=""):
     """Used when creating new tests for quickly looking at the data to make


### PR DESCRIPTION
**Summary**

This PR improves the Python interface structure and testability of the project.

**Changes**

- Move `wrapper.py` from `test/` into `reltrans_api/` to make it part of the actual package.
- Introduce a high-level `ReltransModel` interface.
- Add dependency injection support to enable unit testing without requiring the native library.
- Add a native-independent unit test.
- Preserve existing integration test behaviour.

No numerical logic has been modified.
