### PR TITLE
script for postprocess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ test_reltrans
 Output
 Benchmarks/Benchmark_result*
 benchmark
+post_process

--- a/postprocess/convert_chains.py
+++ b/postprocess/convert_chains.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Convert reltransDCp MCMC chains to include distance parameter."""
+
+import numpy as np
+from astropy.io import fits
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'test'))
+from wrapper import Reltrans
+
+
+def calculate_distance(params, reltrans, xe=20, verbose=0):
+    # TODO: Implement distance calculation
+    # Requires: genreltrans(dset=0) -> logxir, genreltrans(dset=1) -> logxieff
+    # Distance = 10^(0.5*(logxir-logxieff)) / boost
+    raise NotImplementedError(
+        "Distance calculation requires internal Fortran routines. "
+        "Use Fortran post_process executable instead."
+    )
+
+
+def convert_chain(input_chain, output_chain, param_columns, fixed_params):
+    with fits.open(input_chain) as hdul:
+        chain_hdu = hdul['CHAIN']
+        chain_data = chain_hdu.data
+        n_steps = len(chain_data)
+        
+        reltrans = Reltrans()
+        distances = np.zeros(n_steps)
+        
+        for i in range(n_steps):
+            params = {}
+            for pname, col_idx in param_columns.items():
+                if col_idx > 0:
+                    params[pname] = chain_data[i][col_idx - 1]
+                else:
+                    params[pname] = fixed_params[pname]
+            
+            try:
+                distances[i] = calculate_distance(params, reltrans)
+            except NotImplementedError:
+                print("ERROR: Use Fortran post_process executable")
+                sys.exit(1)
+        col_dkpc = fits.Column(name='Dkpc', format='D', unit='kpc', array=distances)
+        new_columns = chain_hdu.columns + fits.ColDefs([col_dkpc])
+        new_hdu = fits.BinTableHDU.from_columns(new_columns, name='CHAIN')
+        primary_hdu = hdul[0].copy()
+        new_hdul = fits.HDUList([primary_hdu, new_hdu])
+        new_hdul.writeto(output_chain, overwrite=True)
+
+
+def main():
+    input_chain = "input_chain.fits"
+    output_chain = "output_chain_with_distance.fits"
+    
+    param_columns = {
+        'h': 7, 'a': 0, 'inc': 8, 'rin': 9, 'rout': 0, 'zcos': 0,
+        'Gamma': 10, 'logxi': 11, 'Afe': 12, 'lognep': 13, 'kTe': 14,
+        'Nh': 0, 'boost': 15, 'Mass': 16, 'Anorm': 17
+    }
+    
+    fixed_params = {'a': 0.998, 'rout': 2e4, 'zcos': 0.0, 'Nh': 0.0}
+    
+    if not os.path.exists(input_chain):
+        print(f"ERROR: Input chain file not found: {input_chain}")
+        sys.exit(1)
+    
+    convert_chain(input_chain, output_chain, param_columns, fixed_params)
+
+
+if __name__ == "__main__":
+    main()

--- a/postprocess/postmakefile
+++ b/postprocess/postmakefile
@@ -1,10 +1,8 @@
 main = post_process.f90
 
 #lib and other stuff to include to the compiler 
-incs = -I ../fftw/fftw_comp/include/ -ffree-line-length-none
-libs = -L ../fftw/fftw_comp/lib/ -lfftw3 -lm \
-	-L ${HEADAS}/lib/ -lfftw3 -lm\
-	-lXSFunctions -lcfitsio -lXSModel -lXSUtil -lXS -lCCfits_2.6 #note: older heasoft versions may need lCCfits_2.5 to compile
+incs = -I${HEADAS}/include -I${HEADAS}/include/fftw -ffree-line-length-none
+libs = -L${HEADAS}/lib -lfftw3 -lm -lXSFunctions -lcfitsio -lXSModel -lXSUtil -lXS -lCCfits_2.6
 fitsio = 
 optimization = -O3
 debug        = -Wall -pedantic


### PR DESCRIPTION
Thanks for opening a PR!

## Checklist
- [x] I have HEASOFT installed and compiled 
- [x] I compiled reltrans
- [x] I have run the test suite (pytest)

## Description of this PR
Converts MCMC parameter chains from reltransDCp model (uses logxi) to rtdist model (uses distance) by calculating and appending distance values for each chain step.

- Fixed postmakefile - Updated paths from non-existent local FFTW to HEASOFT libraries
- Compiled Fortran executable - post_process builds successfully in Docker
- Created Python template - convert_chains.py shows structure but not functional (requires internal Fortran routines)

## Usage
Use Fortran executable: `cd postprocess && make -f postmakefile main && ./post_process`

output
```
root@065b831b8633:/workspace/postprocess# make -f postmakefile main
rm -vf *.o *.mod *~ subroutines/*~
gfortran -O3  -I/opt/heasoft/include -I/opt/heasoft/include/fftw -ffree-line-length-none -L/opt/heasoft/lib -lfftw3 -lm -lXSFunctions -lcfitsio -lXSModel -lXSUtil -lXS -lCCfits_2.6 -c ../amodules.f90
gfortran -O3  -c post_process.f90
gcc      -O3  -c ../relmodels.c ../rellp.c ../relbase.c ../reltable.c ../relutility.c ../donthcomp.c ../xilltable.c ../relcache.c
gfortran -O3  -fno-second-underscore -fno-automatic -fPIC -I/opt/heasoft/include -I/opt/heasoft/include/fftw -ffree-line-length-none *.o -o post_process -L/opt/heasoft/lib -lfftw3 -lm -lXSFunctions -lcfitsio -lXSModel -lXSUtil -lXS -lCCfits_2.6
rm -vf *.o *.mod *~ subroutines/*~
removed 'amodules.o'
removed 'donthcomp.o'
removed 'post_process.o'
removed 'relbase.o'
removed 'relcache.o'
removed 'rellp.o'
removed 'relmodels.o'
removed 'reltable.o'
removed 'relutility.o'
removed 'xilltable.o'
removed 'blcoordinate.mod'
removed 'constants.mod'
removed 'conv_mod.mod'
removed 'dyn_gr.mod'
removed 'ellfunction.mod'
removed 'env_variables.mod'
removed 'obsemitter.mod'
removed 'pemfinding.mod'
removed 'rootsfinding.mod'
removed 'sphericalmotion.mod'
removed 'telematrix.mod'
removed 'telematrix2.mod'
```
Instructions:
Python script conversion - Created postprocess/convert_chains.py as a template showing the complete structure for chain conversion (FITS I/O, parameter mapping, column addition). However, the distance calculation function is not implemented.
Why Python Implementation is Incomplete:
The distance calculation requires calling internal Fortran subroutines (alt_radfunctions_dens, alt_radfuncs_dist, getdcos, init_cont) that are not exposed through the current Python wrapper (test/wrapper.py).
To complete the Python implementation would require:

- Exposing 10+ internal Fortran functions via ctypes
- Complex memory management between Python/Fortran

This PR addresses issue #22 
Please describe what you have changed

## Anything important?
Python script is a template only - The calculate_distance() function raises NotImplementedError because it requires calling internal Fortran subroutines (alt_radfunctions_dens, alt_radfuncs_dist, getdcos, init_cont) that are not exposed through the Python wrapper.
Note: I have left a TODO in `calculate_distance` based on my research {it's just a template} and also included ` except NotImplementedError:` in the main function {we can remove later on}
@bjricketts, what are your views on this ??
One more thing I noticed in `post_process.f90` there were hardcoded files
```
! chainfile = '/Users/nai47/Dropbox/reltrans/OneDrive_1_24-05-2024/paper_dcp_xtemptied_trimmed.out'
chainfile = '/Users/nai47/Dropbox/reltrans/paper_sysf_trimmed_chain_new.out'
newchainfile = '/Users/nai47/Dropbox/reltrans/paper_sysf_trimmed_chain_new_dist.out'
```