### PR TITLE
fix: update printed reltrans version to 2.3.2

### DIFF
--- a/subroutines/initialiser.f90
+++ b/subroutines/initialiser.f90
@@ -45,7 +45,7 @@ subroutine initialiser(firstcall,Emin,Emax,dloge,earx,rnmax,d,needtrans,me,xe,re
          
         needtrans = .true.
         write(*,*)"----------------------------------------------------"
-        write(*,*)"This is RELTRANS v2.3.0: a transfer function model for"
+        write(*,*)"This is RELTRANS v2.3.2: a transfer function model for"
         write(*,*)"X-ray reverberation mapping."
         write(*,*)"Please cite Ingram et al (2019) MNRAS 488 p324-347, "
         write(*,*)"Mastroserio et al (2021) MNRAS 507 p55-73, and "  


### PR DESCRIPTION
## Summary
- update the startup banner to report the correct reltrans code version (v2.3.2)

## Rationale
- issue #84 notes the initial print still shows the old version; this aligns the output with the current release

## Changes
- subroutines/initialiser.f90: change banner string to v2.3.2

## Tests
- not run (string-only change)

Fixes #84