### PR TITLE
variable and functions renaming

### DIFF
--- a/subroutines/common.f90
+++ b/subroutines/common.f90
@@ -20,7 +20,7 @@ module common_types
         integer :: verbose = 0
         ! firstcall: is this the first time the model has been called?
         logical :: firstcall = .true., needtrans = .true., needconv = .true.,test = .false.
-        integer :: me, xe, nex, m, ionvar, refvar
+        integer :: mu_zones, ion_zones, nex, m, ionvar, refvar
 
         ! TODO: are these really constants, or are they hidden variables?
         ! constants
@@ -164,8 +164,8 @@ contains
         type(t_config), intent(inout) :: config
         integer :: get_env_int
         character (len=200) :: get_env_char
-        config%me = get_env_int("MU_ZONES", 1)
-        config%xe = get_env_int("ION_ZONES", 20)
+        config%mu_zones = get_env_int("MU_ZONES", 1)
+        config%ion_zones = get_env_int("ION_ZONES", 20)
         ! verbose:
         ! 0: XSPEC output only
         ! 1: Print quantities to terminal + 0
@@ -246,16 +246,16 @@ contains
 
             ! reallocate the transfer function arrays
             if (allocated(arrays%ker_W0)) deallocate(arrays%ker_W0)
-            allocate(arrays%ker_W0(model_args%nlp,nex,config%nf,config%me,config%xe))
+            allocate(arrays%ker_W0(model_args%nlp,nex,config%nf,config%mu_zones,config%ion_zones))
 
             if (allocated(arrays%ker_W1)) deallocate(arrays%ker_W1)
-            allocate(arrays%ker_W1(model_args%nlp,nex,config%nf,config%me,config%xe))
+            allocate(arrays%ker_W1(model_args%nlp,nex,config%nf,config%mu_zones,config%ion_zones))
 
             if (allocated(arrays%ker_W2)) deallocate(arrays%ker_W2)
-            allocate(arrays%ker_W2(model_args%nlp,nex,config%nf,config%me,config%xe))
+            allocate(arrays%ker_W2(model_args%nlp,nex,config%nf,config%mu_zones,config%ion_zones))
 
             if (allocated(arrays%ker_W3)) deallocate(arrays%ker_W3)
-            allocate(arrays%ker_W3(model_args%nlp,nex,config%nf,config%me,config%xe))
+            allocate(arrays%ker_W3(model_args%nlp,nex,config%nf,config%mu_zones,config%ion_zones))
 
             if (allocated(arrays%ReW0)) deallocate(arrays%ReW0)
             allocate(arrays%ReW0(model_args%nlp,nex,config%nf))

--- a/subroutines/common.f90
+++ b/subroutines/common.f90
@@ -192,8 +192,8 @@ contains
         write(*,*)"----------------------------------------------------"
         write(*,*)" *** ENVIRONMENT VARIABLES *** "
         write(*,*)
-        write(*,*) 'RADIAL ZONES', config%xe
-        write(*,*) 'ANGLE ZONES', config%me
+        write(*,*) 'RADIAL ZONES', config%ion_zones
+        write(*,*) 'ANGLE ZONES', config%mu_zones
         if (adensity .eq. 0.0) then
             write(*,*) 'A_DENSITY:', adensity, 'Density profile is constant'
         else

--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -490,7 +490,8 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
                 arrays%ImGbar)
         end if
     else if (nlp .gt. 1 .and. model_args%beta_p .eq. 0.) then
-        call raw_cross_spectrum(nex, arrays%earx, config%nf, real(config%flo),               &
+        call full_cross_spectrum_absorbed_resp(nex, arrays%earx,                &
+            config%nf, real(config%flo),                                        &
             real(config%fhi), nlp, arrays%contx, absorbx, real(tauso),         &
             real(gso),arrays%ReW0, arrays%ImW0, arrays%ReW1,arrays%ImW1,       &
             arrays%ReW2,arrays%ImW2, arrays%ReW3,arrays%ImW3,                  &
@@ -500,7 +501,8 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
             model_args%resp_matr, arrays%ReGrawa,arrays%ImGrawa)
     else
         ! Calculate raw FT of the full spectrum without absorption
-        call raw_full_spectrum(nex, arrays%earx, config%nf, real(config%flo),               &
+        call raw_cross_spectrum(nex, arrays%earx, config%nf,                    &
+            real(config%flo),                                                   &
             real(config%fhi), nlp, arrays%contx, real(tauso), real(gso),       &
             arrays%ReW0, arrays%ImW0, arrays%ReW1, arrays%ImW1,arrays%ReW2,    &
             arrays%ImW2, arrays%ReW3, arrays%ImW3,real(model_args%h),          &
@@ -534,7 +536,8 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
         ! In this case, calculate the lag-energy spectrum
         ! Calculate raw cross-spectrum from Sraw(E,\nu) and the reference band
         ! parameters
-        ! note: this must be done by raw_cross_spectrum for two incoherent lamp posts, hence
+        ! note: this must be done by full_cross_spectrum_absorbed_resp for two
+        ! incoherent lamp posts, hence
         ! the skip below
         if (nlp .eq. 1 .or. model_args%beta_p .ne. 0.) then
             if (model_args%ReIm .gt. 0.0) then

--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -12,10 +12,10 @@ contains
         integer, intent(in) :: nlp
         type(t_config), intent(in) :: config
         ! allocate arrays for radial profiles
-        allocate(dfer_arr(config%xe))
-        allocate(logxir(config%xe))
-        allocate(gsdr(config%xe))
-        allocate(logner(config%xe))
+        allocate(dfer_arr(config%ion_zones))
+        allocate(logxir(config%ion_zones))
+        allocate(gsdr(config%ion_zones))
+        allocate(logner(config%ion_zones))
 
         ! allocate GR arrays
         allocate (cosd(ndelta,nlp))
@@ -139,13 +139,13 @@ contains
         ! the rawS subroutine to calculate the cross-spectrum
         ionvariation = 1
         ! Loop over radius, emission angle and frequency
-        do rbin = 1, config%xe !Loop over radial zones
+        do rbin = 1, config%ion_zones !Loop over radial zones
             ! Set parameters with radial dependence
             Gamma0 = real(model_args%Gamma)
             logne = logner(rbin)
             Cutoff_0 = real(gsdr(rbin)) * model_args%Cutoff_s
             logxi0 = real(logxir(rbin))
-            if (config%xe .eq. 1)then
+            if (config%ion_zones .eq. 1)then
                 Cutoff_0 = model_args%Cutoff_s
                 logne = model_args%lognep
                 logxi0 = model_args%logxi
@@ -154,11 +154,11 @@ contains
             if (logxi0 .eq. 0.0 .or. config%ionvar .eq. 0) then
                 ionvariation = 0.0
             end if
-            do mubin = 1, config%me !loop over emission angle zones
+            do mubin = 1, config%mu_zones !loop over emission angle zones
                 ! Calculate input emission angle
-                mue = (real(mubin) - 0.5) / real(config%me)
+                mue = (real(mubin) - 0.5) / real(config%mu_zones)
                 thetae = acos(mue) * 180.0 / real(pi)
-                if (config%me .eq. 1) thetae = real(model_args%inc)
+                if (config%mu_zones .eq. 1) thetae = real(model_args%inc)
                 ! Call restframe reflection model
                 call rest_frame(arrays%earx, nex, Gamma0, model_args%Afe,      &
                     logne,Cutoff_0, logxi0, thetae, model_args%Cp, photarx)
@@ -395,7 +395,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
            model_args%honr, d, rnmax, model_args%zcos, model_args%b1,          &
            model_args%b2, model_args%qboost, model_args%eta_0, fcons,          &
            config%nro, config%nphi, nex, config%dloge, config%nf,config%fhi,   &
-           config%flo, config%me, config%xe, arrays%ker_W0,arrays%ker_W1,      &
+           config%flo, config%mu_zones, config%ion_zones, arrays%ker_W0,arrays%ker_W1,      &
            arrays%ker_W2, arrays%ker_W3, frobs, frrel)
        ! print *, 'gso ', gso(1)
     end if
@@ -422,14 +422,14 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
            config%verbose, dset,model_args%Anorm, arrays%contx_int,            &
            model_args%eta)
 
-       call radfunctions_dens(config%verbose, config%xe, model_args%rin,       &
+       call radfunctions_dens(config%verbose, config%ion_zones, model_args%rin,       &
            rnmax, model_args%eta_0, dble(model_args%logxi),                    &
            dble(model_args%lognep), model_args%a, model_args%h,                &
            model_args%Gamma, model_args%honr, rlp, dcosdr, cosd,               &
            arrays%contx_int,ndelta, nlp, config%rmin, npts, logxir, gsdr,      &
            logner, dfer_arr)
     else
-        call radfuncs_dist(config%xe, model_args%rin, rnmax,model_args%b1,     &
+        call radfuncs_dist(config%ion_zones, model_args%rin, rnmax,model_args%b1,     &
             model_args%b2, model_args%qboost, fcons,                           &
             & dble(model_args%lognep), model_args%a, model_args%h(1),          &
             model_args%honr, rlp, dcosdr, cosd, ndelta, config%rmin,npts(1),   &
@@ -490,7 +490,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
                 arrays%ImGbar)
         end if
     else if (nlp .gt. 1 .and. model_args%beta_p .eq. 0.) then
-        call rawG(nex, arrays%earx, config%nf, real(config%flo),               &
+        call raw_cross_spectrum(nex, arrays%earx, config%nf, real(config%flo),               &
             real(config%fhi), nlp, arrays%contx, absorbx, real(tauso),         &
             real(gso),arrays%ReW0, arrays%ImW0, arrays%ReW1,arrays%ImW1,       &
             arrays%ReW2,arrays%ImW2, arrays%ReW3,arrays%ImW3,                  &
@@ -500,7 +500,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
             model_args%resp_matr, arrays%ReGrawa,arrays%ImGrawa)
     else
         ! Calculate raw FT of the full spectrum without absorption
-        call rawS(nex, arrays%earx, config%nf, real(config%flo),               &
+        call raw_full_spectrum(nex, arrays%earx, config%nf, real(config%flo),               &
             real(config%fhi), nlp, arrays%contx, real(tauso), real(gso),       &
             arrays%ReW0, arrays%ImW0, arrays%ReW1, arrays%ImW1,arrays%ReW2,    &
             arrays%ImW2, arrays%ReW3, arrays%ImW3,real(model_args%h),          &
@@ -534,7 +534,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
         ! In this case, calculate the lag-energy spectrum
         ! Calculate raw cross-spectrum from Sraw(E,\nu) and the reference band
         ! parameters
-        ! note: this must be done by rawG for two incoherent lamp posts, hence
+        ! note: this must be done by raw_cross_spectrum for two incoherent lamp posts, hence
         ! the skip below
         if (nlp .eq. 1 .or. model_args%beta_p .ne. 0.) then
             if (model_args%ReIm .gt. 0.0) then

--- a/subroutines/radial_profiles/radfunctions_dens.f90
+++ b/subroutines/radial_profiles/radfunctions_dens.f90
@@ -19,8 +19,12 @@ subroutine radfunctions_dens(config, model_args, arrays)
 
     real                           :: gso(model_args%nlp)
     double precision :: rlp_column(ndelta),dcosdr_column(ndelta),cosd_column(ndelta), dgsofac
-    integer          :: i, kk, get_index, get_env_int, l, m
-    double precision :: rp, logxinorm, lognenorm,  mus, interper, newtex, mui, dinang, gsd(model_args%nlp), dglpfacthick
+    integer          :: i, kk, get_index, l, m
+    ! old variable declaration
+    ! integer          :: get_env_int
+    double precision :: logxinorm, lognenorm,  mus, interper, newtex, mui, dinang, gsd(model_args%nlp)
+    ! old variable declaration
+    ! double precision :: rp, dglpfacthick
     double precision :: xi_lp(config%xe,model_args%nlp), logxi_lp(config%xe,model_args%nlp), logxip_lp(model_args%nlp)
     double precision :: xitot, xiraw, mylogne, mudisk, gsd_temp
     double precision, allocatable :: rad(:)
@@ -82,7 +86,7 @@ subroutine radfunctions_dens(config, model_args, arrays)
             logxi_lp(i,m) = log10(xi_lp(i,m)) - logner(i) - lognenorm         &
                 - logxinorm + dble(model_args%lognep) + dble(model_args%logxi)
         end do
-        logxip_lp(m) = max(maxval(logxi_lp(:,m)),0.)
+        logxip_lp(m) = max(maxval(logxi_lp(:,m)),0.d0)
     end do
     
     !Write radii, ionisation (for both and each LP), gamma factors, and log(xi(r))+log(ne(r)) (which is nearly the same as
@@ -91,10 +95,13 @@ subroutine radfunctions_dens(config, model_args, arrays)
     !to recover the correct scaling of the emissivity at large radii
     !2) in order to correctly compare the dfer_arr array with the single LP case, it has to be renormalized by (1+eta_0)
     if( config%verbose .gt. 1 ) then
-        print*, "Peak ionisations from each LP: first " , logxip_lp(1), " second ", logxip_lp(2)
+        do m = 1, model_args%nlp
+            print*, "Peak ionisation from LP", m, ": ", logxip_lp(m)
+        end do
         open (unit = 27, file = 'Output/RadialScalings.dat', status='replace', action = 'write')
             do i = 1, config%xe
-                write(27,*) rad(i), logxir(i), gsdr(i), logxir(i)+logner(i), logxi_lp(i,1), logxi_lp(i,2), dfer_arr(i) 
+                write(27,*) rad(i), logxir(i), gsdr(i), logxir(i)+logner(i),   &
+                    (logxi_lp(i,m), m=1,model_args%nlp), dfer_arr(i)
             end do 
         close(27)    
     end if

--- a/subroutines/radial_profiles/radfunctions_dens.f90
+++ b/subroutines/radial_profiles/radfunctions_dens.f90
@@ -1,8 +1,13 @@
 !-----------------------------------------------------------------------
 subroutine radfunctions_dens(config, model_args, arrays)
-    ! In  : xe,rin,rnmax,eta_0,logxip,spin,h,honr,rlp,dcosdr,cosd,ndelta,rmin,npts
-    ! logxir(xe),gsdr(xe)   logxi (ionization parameter) and gsd (source to disc blueshift) as a function of radius
-    ! Out : logxir(1:xe), gsdr(1:xe), logner(1:xe)
+    ! In  : config      - global configuration (e.g. number of radial grid points: config%xe)
+    !       model_args  - model parameters (e.g. geometry, logxi, lognep, honr, number of LPs: model_args%nlp)
+    !       arrays      - input arrays bundled in t_arrays (if applicable; main radial profiles come from modules)
+    !      Uses/updates module arrays from radial_grids:
+    !       logxir(1:config%xe) - log10 of ionization parameter as a function of radius
+    !       gsdr(1:config%xe)   - source-to-disc blueshift factor as a function of radius
+    !       logner(1:config%xe) - log10 of electron density as a function of radius
+    !       dfer_arr(1:config%xe) - emissivity-related radial scaling array
     use common_types
     use env_variables
     use dyn_gr, only: ndelta, rlp, dcosdr, cosd, npts

--- a/subroutines/radial_profiles/radfunctions_dens.f90
+++ b/subroutines/radial_profiles/radfunctions_dens.f90
@@ -1,13 +1,13 @@
 !-----------------------------------------------------------------------
 subroutine radfunctions_dens(config, model_args, arrays)
-    ! In  : config      - global configuration (e.g. number of radial grid points: config%xe)
+    ! In  : config      - global configuration (e.g. number of radial grid points: config%ion_zones)
     !       model_args  - model parameters (e.g. geometry, logxi, lognep, honr, number of LPs: model_args%nlp)
     !       arrays      - input arrays bundled in t_arrays (if applicable; main radial profiles come from modules)
     !      Uses/updates module arrays from radial_grids:
-    !       logxir(1:config%xe) - log10 of ionization parameter as a function of radius
-    !       gsdr(1:config%xe)   - source-to-disc blueshift factor as a function of radius
-    !       logner(1:config%xe) - log10 of electron density as a function of radius
-    !       dfer_arr(1:config%xe) - emissivity-related radial scaling array
+    !       logxir(1:config%ion_zones) - log10 of ionization parameter as a function of radius
+    !       gsdr(1:config%ion_zones)   - source-to-disc blueshift factor as a function of radius
+    !       logner(1:config%ion_zones) - log10 of electron density as a function of radius
+    !       dfer_arr(1:config%ion_zones) - emissivity-related radial scaling array
     use common_types
     use env_variables
     use dyn_gr, only: ndelta, rlp, dcosdr, cosd, npts
@@ -25,23 +25,23 @@ subroutine radfunctions_dens(config, model_args, arrays)
     double precision :: logxinorm, lognenorm,  mus, interper, newtex, mui, dinang, gsd(model_args%nlp)
     ! old variable declaration
     ! double precision :: rp, dglpfacthick
-    double precision :: xi_lp(config%xe,model_args%nlp), logxi_lp(config%xe,model_args%nlp), logxip_lp(model_args%nlp)
+    double precision :: xi_lp(config%ion_zones,model_args%nlp), logxi_lp(config%ion_zones,model_args%nlp), logxip_lp(model_args%nlp)
     double precision :: xitot, xiraw, mylogne, mudisk, gsd_temp
     double precision, allocatable :: rad(:)
 
     ! Set disk opening angle
     mudisk   = model_args%honr / sqrt( model_args%honr**2 + 1.d0  )
     
-    allocate(rad(config%xe))
+    allocate(rad(config%ion_zones))
     !Now calculate logxi itself
     ! The loop calculates the raw xi and raw n_e.
     ! This means they are without normalization: only to find the maximum and the minimum. Remember that the max of the ionisation is not the same as the minumim in the density because the flux depends on r
     !The loops calculates also the correction factor mui
 
     !TBD: include luminosity ratio between LPs 
-    do i = 1, config%xe
-        rad(i) = (config%rnmax/model_args%rin)**(real(i-1) / real(config%xe))
-        rad(i) = rad(i) + (config%rnmax/model_args%rin)**(real(i) / real(config%xe))
+    do i = 1, config%ion_zones
+        rad(i) = (config%rnmax/model_args%rin)**(real(i-1) / real(config%ion_zones))
+        rad(i) = rad(i) + (config%rnmax/model_args%rin)**(real(i) / real(config%ion_zones))
         rad(i) = rad(i) * model_args%rin * 0.5
         !Initialize total ionization tracker
         xitot = 0. 
@@ -82,7 +82,7 @@ subroutine radfunctions_dens(config, model_args, arrays)
     logner = logner - (lognenorm - dble(model_args%lognep))
     
     do m=1,model_args%nlp
-        do i=1,config%xe
+        do i=1,config%ion_zones
             logxi_lp(i,m) = log10(xi_lp(i,m)) - logner(i) - lognenorm         &
                 - logxinorm + dble(model_args%lognep) + dble(model_args%logxi)
         end do
@@ -99,7 +99,7 @@ subroutine radfunctions_dens(config, model_args, arrays)
             print*, "Peak ionisation from LP", m, ": ", logxip_lp(m)
         end do
         open (unit = 27, file = 'Output/RadialScalings.dat', status='replace', action = 'write')
-            do i = 1, config%xe
+            do i = 1, config%ion_zones
                 write(27,*) rad(i), logxir(i), gsdr(i), logxir(i)+logner(i),   &
                     (logxi_lp(i,m), m=1,model_args%nlp), dfer_arr(i)
             end do 

--- a/subroutines/rawG.f90
+++ b/subroutines/rawG.f90
@@ -1,4 +1,5 @@
-subroutine raw_cross_spectrum(nex, earx, nf, flo, fhi, nlp, contx,             &
+subroutine full_cross_spectrum_absorbed_resp(nex, earx, nf, flo, fhi,          &
+                nlp, contx,                                                    &
                 absorbx, tauso, gso, ReW0, ImW0, ReW1, ImW1, ReW2, ImW2,      &
                 ReW3, ImW3, h, z, Gamma, eta,                                  &
                 boost, ReIm, g, DelAB, ionvar, DC, resp_matr, ReGraw, ImGraw)
@@ -90,4 +91,4 @@ subroutine raw_cross_spectrum(nex, earx, nf, flo, fhi, nlp, contx,             &
     end do   
 
     return 
-end subroutine raw_cross_spectrum
+end subroutine full_cross_spectrum_absorbed_resp

--- a/subroutines/rawG.f90
+++ b/subroutines/rawG.f90
@@ -1,5 +1,7 @@
-subroutine raw_cross_spectrum(nex,earx,nf,flo,fhi,nlp,contx,absorbx,tauso,gso,ReW0,ImW0,ReW1,ImW1,ReW2,ImW2,ReW3,ImW3,h,z,Gamma,eta,&
-                boost,ReIm,g,DelAB,ionvar,DC,resp_matr,ReGraw,ImGraw)
+subroutine raw_cross_spectrum(nex, earx, nf, flo, fhi, nlp, contx,             &
+                absorbx, tauso, gso, ReW0, ImW0, ReW1, ImW1, ReW2, ImW2,      &
+                ReW3, ImW3, h, z, Gamma, eta,                                  &
+                boost, ReIm, g, DelAB, ionvar, DC, resp_matr, ReGraw, ImGraw)
                 
     use constants
     implicit none

--- a/subroutines/rawG.f90
+++ b/subroutines/rawG.f90
@@ -1,4 +1,4 @@
-subroutine rawG(nex,earx,nf,flo,fhi,nlp,contx,absorbx,tauso,gso,ReW0,ImW0,ReW1,ImW1,ReW2,ImW2,ReW3,ImW3,h,z,Gamma,eta,&
+subroutine raw_cross_spectrum(nex,earx,nf,flo,fhi,nlp,contx,absorbx,tauso,gso,ReW0,ImW0,ReW1,ImW1,ReW2,ImW2,ReW3,ImW3,h,z,Gamma,eta,&
                 boost,ReIm,g,DelAB,ionvar,DC,resp_matr,ReGraw,ImGraw)
                 
     use constants
@@ -88,4 +88,4 @@ subroutine rawG(nex,earx,nf,flo,fhi,nlp,contx,absorbx,tauso,gso,ReW0,ImW0,ReW1,I
     end do   
 
     return 
-end subroutine rawG
+end subroutine raw_cross_spectrum

--- a/subroutines/rawS.f90
+++ b/subroutines/rawS.f90
@@ -1,4 +1,4 @@
-subroutine raw_full_spectrum(nex, earx, nf, flo, fhi, nlp, contx,              &
+subroutine raw_cross_spectrum(nex, earx, nf, flo, fhi, nlp, contx,             &
                 tauso, gso, ReW0, ImW0, ReW1, ImW1, ReW2, ImW2,               &
                 ReW3, ImW3, h, z, Gamma, eta,                                  &
                 beta_p, boost, g, DelAB, ionvar, DC, ReSraw, ImSraw)
@@ -118,4 +118,4 @@ subroutine raw_full_spectrum(nex, earx, nf, flo, fhi, nlp, contx,              &
      end do
 
     return
-end subroutine raw_full_spectrum
+end subroutine raw_cross_spectrum

--- a/subroutines/rawS.f90
+++ b/subroutines/rawS.f90
@@ -1,4 +1,4 @@
-subroutine rawS(nex,earx,nf,flo,fhi,nlp,contx,tauso,gso,ReW0,ImW0,ReW1,ImW1,ReW2,ImW2,ReW3,ImW3,h,z,Gamma,eta,&
+subroutine raw_full_spectrum(nex,earx,nf,flo,fhi,nlp,contx,tauso,gso,ReW0,ImW0,ReW1,ImW1,ReW2,ImW2,ReW3,ImW3,h,z,Gamma,eta,&
                 beta_p,boost,g,DelAB,ionvar,DC,ReSraw,ImSraw)
     ! Calculates the FT of the spectrum before multiplying by the absorption model
     !
@@ -116,4 +116,4 @@ subroutine rawS(nex,earx,nf,flo,fhi,nlp,contx,tauso,gso,ReW0,ImW0,ReW1,ImW1,ReW2
      end do
 
     return
-end subroutine rawS
+end subroutine raw_full_spectrum

--- a/subroutines/rawS.f90
+++ b/subroutines/rawS.f90
@@ -1,5 +1,7 @@
-subroutine raw_full_spectrum(nex,earx,nf,flo,fhi,nlp,contx,tauso,gso,ReW0,ImW0,ReW1,ImW1,ReW2,ImW2,ReW3,ImW3,h,z,Gamma,eta,&
-                beta_p,boost,g,DelAB,ionvar,DC,ReSraw,ImSraw)
+subroutine raw_full_spectrum(nex, earx, nf, flo, fhi, nlp, contx,              &
+                tauso, gso, ReW0, ImW0, ReW1, ImW1, ReW2, ImW2,               &
+                ReW3, ImW3, h, z, Gamma, eta,                                  &
+                beta_p, boost, g, DelAB, ionvar, DC, ReSraw, ImSraw)
     ! Calculates the FT of the spectrum before multiplying by the absorption model
     !
     ! Input: continuum model (contx is f(E) in the papers) and the reflection transfer functions

--- a/subroutines/strans.f90
+++ b/subroutines/strans.f90
@@ -1,6 +1,6 @@
 !-----------------------------------------------------------------------
 subroutine rtrans(verbose,dset,nlp,spin,h,mu0,Gamma,rin,rout,honr,d,rnmax,zcos,b1,b2,qboost,eta_0,&
-                  fcons,nro,nphi,ne,dloge,nf,fhi,flo,me,xe,ker_W0,ker_W1,ker_W2,ker_W3,frobs,frrel)
+                  fcons,nro,nphi,ne,dloge,nf,fhi,flo,mu_zones,ion_zones,ker_W0,ker_W1,ker_W2,ker_W3,frobs,frrel)
     ! Code to calculate the transfer function for an accretion disk.
     ! This code first does full GR ray tracing for a camera with impact parameters < bmax
     ! It then also does straight line ray tracing for impact parameters >bmax
@@ -23,13 +23,13 @@ subroutine rtrans(verbose,dset,nlp,spin,h,mu0,Gamma,rin,rout,honr,d,rnmax,zcos,b
     ! nro,nphi              Number of pixels on the observer's camera (b and phib)
     ! ne, dloge             Number of energy bins and maximum energy (compatible with FFT convolution)
     ! nf,fhi,flo            nf = Number of logarithmic frequency bins used, range= flo to fhi
-    ! me                    Number of mue bins
-    ! xe                    Number of logr bins: bins 1:xe-1 are logarithmically spaced, bin xe is everything else
+    ! mu_zones                  Number of mue bins
+    ! ion_zones                 Number of logr bins: bins 1:ion_zones-1 are logarithmically spaced, bin ion_zones is everything else
     ! OUTPUT
-    ! ker_W0(nlp,ne,nf,me,xe)  Transfer function W0 - linear transfer function
-    ! ker_W1(nlp,ne,nf,me,xe)  Transfer function W1 - one aspect of photon index variations
-    ! ker_W2(nlp,ne,nf,me,xe)  Transfer function W2 - other aspect of photon index variations
-    ! ker_W3(nlp,ne,nf,me,xe)  Transfer function W3 - ionization variations
+    ! ker_W0(nlp,ne,nf,mu_zones,ion_zones)  Transfer function W0 - linear transfer function
+    ! ker_W1(nlp,ne,nf,mu_zones,ion_zones)  Transfer function W1 - one aspect of photon index variations
+    ! ker_W2(nlp,ne,nf,mu_zones,ion_zones)  Transfer function W2 - other aspect of photon index variations
+    ! ker_W3(nlp,ne,nf,mu_zones,ion_zones)  Transfer function W3 - ionization variations
     ! frobs                 Observer's reflection fraction
     ! frrel                 Reflection fraction defined by relxilllp
     use dyn_gr
@@ -37,7 +37,7 @@ subroutine rtrans(verbose,dset,nlp,spin,h,mu0,Gamma,rin,rout,honr,d,rnmax,zcos,b
     use radial_grids
     use gr_continuum
     implicit none
-    integer nro,nphi,ne,nf,me,xe,dset,nlp
+    integer nro,nphi,ne,nf,mu_zones,ion_zones,dset,nlp
     double precision spin,h(nlp),mu0,Gamma,rin,rout,zcos,fhi,flo,honr
     double precision b1,b2,qboost
     double precision fcons,cosdout(nlp)
@@ -62,7 +62,7 @@ subroutine rtrans(verbose,dset,nlp,spin,h,mu0,Gamma,rin,rout,honr,d,rnmax,zcos,b
     logical dotrace
 
     !new stuff - move back above once it's implemented properly    
-    complex ker_W0(nlp,ne,nf,me,xe),ker_W1(nlp,ne,nf,me,xe),ker_W2(nlp,ne,nf,me,xe),ker_W3(nlp,ne,nf,me,xe)
+    complex ker_W0(nlp,ne,nf,mu_zones,ion_zones),ker_W1(nlp,ne,nf,mu_zones,ion_zones),ker_W2(nlp,ne,nf,mu_zones,ion_zones),ker_W3(nlp,ne,nf,mu_zones,ion_zones)
     real emisfac,thetafac(nlp),kfac,normfac
     
     !arrays to save the transfer function
@@ -160,7 +160,7 @@ subroutine rtrans(verbose,dset,nlp,spin,h,mu0,Gamma,rin,rout,honr,d,rnmax,zcos,b
     if( fhi .lt. tiny(fhi) ) fi(1) = 0.0d0
 
     !initialize radius grid, angles, and transfer functions
-    dlogr    = log10(rnmax/rin) / real(xe-1)
+    dlogr    = log10(rnmax/rin) / real(ion_zones-1)
     cos0     = mu0
     sin0     = sqrt(1.0-cos0**2)
     frobs    = 0.0 !Initialised observer's reflection fraction
@@ -237,12 +237,12 @@ subroutine rtrans(verbose,dset,nlp,spin,h,mu0,Gamma,rin,rout,honr,d,rnmax,zcos,b
                         !Work out radial bin
                         rbin = ceiling( log10(re/rin) / dlogr )
                         rbin = MAX( rbin , 1  )
-                        rbin = MIN( rbin , xe )
+                        rbin = MIN( rbin , ion_zones )
                         !Add to the radial dependence of the transfer function TBD MAKE SURE THIS IS RIGHT
                         dfer_arr(rbin) = dfer_arr(rbin) + dFe(nl)                 
                         !Calculate emission angle and work out which mue bin to add to
                         mue   = demang(spin,mu0,re,alpha,beta)
-                        mubin = ceiling( mue * dble(me) )
+                        mubin = ceiling( mue * dble(mu_zones) )
                         !calculate the extra factors for w2/3
                         !if (nl .eq. 1 .and. nlp .gt. 1) then
                         !    emisfac = emissivity(1)+eta_0*emissivity(2)                          
@@ -335,12 +335,12 @@ subroutine rtrans(verbose,dset,nlp,spin,h,mu0,Gamma,rin,rout,honr,d,rnmax,zcos,b
                     !Work out radial bin
                     rbin = ceiling( log10(re/rin) / dlogr )
                     rbin = MAX( rbin , 1  )
-                    rbin = MIN( rbin , xe )
+                    rbin = MIN( rbin , ion_zones )
                     !Add to the radial dependence of the transfer function
                     dfer_arr(rbin) = dfer_arr(rbin) + dFe(nl)                     
                     !Calculate emission angle and work out which mue bin to add to
                     mue = demang(spin,mu0,re,alpha,beta)
-                    mubin = ceiling( mue * dble(me) )
+                    mubin = ceiling( mue * dble(mu_zones) )
                     !calculate the extra factors for w2/3
                     if (nlp .gt. 1) then
                         emisfac = (emissivity(1)+eta_0*emissivity(2))/(1.+eta_0)

--- a/subroutines/strans.f90
+++ b/subroutines/strans.f90
@@ -62,7 +62,10 @@ subroutine rtrans(verbose,dset,nlp,spin,h,mu0,Gamma,rin,rout,honr,d,rnmax,zcos,b
     logical dotrace
 
     !new stuff - move back above once it's implemented properly    
-    complex ker_W0(nlp,ne,nf,mu_zones,ion_zones),ker_W1(nlp,ne,nf,mu_zones,ion_zones),ker_W2(nlp,ne,nf,mu_zones,ion_zones),ker_W3(nlp,ne,nf,mu_zones,ion_zones)
+    complex ker_W0(nlp,ne,nf,mu_zones,ion_zones),                              &
+        ker_W1(nlp,ne,nf,mu_zones,ion_zones),                              &
+        ker_W2(nlp,ne,nf,mu_zones,ion_zones),                              &
+        ker_W3(nlp,ne,nf,mu_zones,ion_zones)
     real emisfac,thetafac(nlp),kfac,normfac
     
     !arrays to save the transfer function


### PR DESCRIPTION
Thanks for opening a PR!

## Checklist
- [x] I have HEASOFT installed and compiled 
- [x] I compiled reltrans
- [x] I have run the test suite (pytest)

## Description of this PR
### Variable Renamings in t_config type:
- `me` → `mu_zones` (emission angle zones)
- `xe` → `ion_zones` (ionization zones)
#### Function Renamings:
- `rawS` -> `raw_cross_spectrum`
- `rawG`-> `full_cross_spectrum_absorbed_resp`

Instructions:

This PR addresses issue #88 


## Anything important?
So I have referred to the [documentation of reltrans](https://reltransdocs.readthedocs.io/en/latest/installation.html) for `xe` and `me`, and from web surfing, I renamed `rawG` and `rawS`
