### PR TITLE
Refactor: radfunction dens

### DIFF
--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -422,12 +422,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
            config%verbose, dset,model_args%Anorm, arrays%contx_int,            &
            model_args%eta)
 
-       call radfunctions_dens(config%verbose, config%xe, model_args%rin,       &
-           rnmax, model_args%eta_0, dble(model_args%logxi),                    &
-           dble(model_args%lognep), model_args%a, model_args%h,                &
-           model_args%Gamma, model_args%honr, rlp, dcosdr, cosd,               &
-           arrays%contx_int,ndelta, nlp, config%rmin, npts, logxir, gsdr,      &
-           logner, dfer_arr)
+       call radfunctions_dens(config, model_args, arrays)
     else
         call radfuncs_dist(config%xe, model_args%rin, rnmax,model_args%b1,     &
             model_args%b2, model_args%qboost, fcons,                           &

--- a/subroutines/header.h
+++ b/subroutines/header.h
@@ -1,3 +1,5 @@
+include 'subroutines/common.f90'
+
 include 'subroutines/continuum/getcont.f90'
 include 'subroutines/continuum/init_cont.f90'
 
@@ -31,8 +33,6 @@ include 'subroutines/radial_profiles/radfuncs_dist.f90'
 include 'subroutines/radial_profiles/sysfref.f90'
 include 'subroutines/radial_profiles/xiraw.f90'
 include 'subroutines/radial_profiles/zA_logne.f90'
-
-include 'subroutines/common.f90'
 
 include 'subroutines/angles.f90'
 include 'subroutines/ave_weight2D.f90'

--- a/subroutines/radial_profiles/radfunctions_dens.f90
+++ b/subroutines/radial_profiles/radfunctions_dens.f90
@@ -19,8 +19,12 @@ subroutine radfunctions_dens(config, model_args, arrays)
 
     real                           :: gso(model_args%nlp)
     double precision :: rlp_column(ndelta),dcosdr_column(ndelta),cosd_column(ndelta), dgsofac
-    integer          :: i, kk, get_index, get_env_int, l, m
-    double precision :: rp, logxinorm, lognenorm,  mus, interper, newtex, mui, dinang, gsd(model_args%nlp), dglpfacthick
+    integer          :: i, kk, get_index, l, m
+    ! old variable declaration
+    ! integer          :: get_env_int
+    double precision :: logxinorm, lognenorm,  mus, interper, newtex, mui, dinang, gsd(model_args%nlp)
+    ! old variable declaration
+    ! double precision :: rp, dglpfacthick
     double precision :: xi_lp(config%xe,model_args%nlp), logxi_lp(config%xe,model_args%nlp), logxip_lp(model_args%nlp)
     double precision :: xitot, xiraw, mylogne, mudisk, gsd_temp
     double precision, allocatable :: rad(:)
@@ -82,7 +86,7 @@ subroutine radfunctions_dens(config, model_args, arrays)
             logxi_lp(i,m) = log10(xi_lp(i,m)) - logner(i) - lognenorm         &
                 - logxinorm + dble(model_args%lognep) + dble(model_args%logxi)
         end do
-        logxip_lp(m) = max(maxval(logxi_lp(:,m)),0.)
+        logxip_lp(m) = max(maxval(logxi_lp(:,m)),0.d0)
     end do
     
     !Write radii, ionisation (for both and each LP), gamma factors, and log(xi(r))+log(ne(r)) (which is nearly the same as
@@ -91,10 +95,13 @@ subroutine radfunctions_dens(config, model_args, arrays)
     !to recover the correct scaling of the emissivity at large radii
     !2) in order to correctly compare the dfer_arr array with the single LP case, it has to be renormalized by (1+eta_0)
     if( config%verbose .gt. 1 ) then
-        print*, "Peak ionisations from each LP: first " , logxip_lp(1), " second ", logxip_lp(2)
+        do m = 1, model_args%nlp
+            print*, "Peak ionisation from LP", m, ": ", logxip_lp(m)
+        end do
         open (unit = 27, file = 'Output/RadialScalings.dat', status='replace', action = 'write')
             do i = 1, config%xe
-                write(27,*) rad(i), logxir(i), gsdr(i), logxir(i)+logner(i), logxi_lp(i,1), logxi_lp(i,2), dfer_arr(i) 
+                write(27,*) rad(i), logxir(i), gsdr(i), logxir(i)+logner(i),   &
+                    (logxi_lp(i,m), m=1,model_args%nlp), dfer_arr(i)
             end do 
         close(27)    
     end if

--- a/subroutines/radial_profiles/radfunctions_dens.f90
+++ b/subroutines/radial_profiles/radfunctions_dens.f90
@@ -1,8 +1,13 @@
 !-----------------------------------------------------------------------
 subroutine radfunctions_dens(config, model_args, arrays)
-    ! In  : xe,rin,rnmax,eta_0,logxip,spin,h,honr,rlp,dcosdr,cosd,ndelta,rmin,npts
-    ! logxir(xe),gsdr(xe)   logxi (ionization parameter) and gsd (source to disc blueshift) as a function of radius
-    ! Out : logxir(1:xe), gsdr(1:xe), logner(1:xe)
+    ! In  : config      - global configuration (e.g. number of radial grid points: config%xe)
+    !       model_args  - model parameters (e.g. geometry, logxi, lognep, honr, number of LPs: model_args%nlp)
+    !       arrays      - input arrays bundled in t_arrays (if applicable; main radial profiles come from modules)
+    !      Uses/updates module arrays from radial_grids:
+    !       logxir(1:config%xe) - log10 of ionization parameter as a function of radius
+    !       gsdr(1:config%xe)   - source-to-disc blueshift factor as a function of radius
+    !       logner(1:config%xe) - log10 of electron density as a function of radius
+    !       dfer_arr(1:config%xe) - emissivity-related radial scaling array
     use common_types
     use env_variables
     use dyn_gr, only: ndelta, rlp, dcosdr, cosd, npts

--- a/subroutines/radial_profiles/radfunctions_dens.f90
+++ b/subroutines/radial_profiles/radfunctions_dens.f90
@@ -1,57 +1,64 @@
 !-----------------------------------------------------------------------
-subroutine radfunctions_dens(verbose,xe,rin,rnmax,eta_0,logxip,lognep,spin,h,Gamma,honr,rlp,dcosdr&
-     &,cosd,contx_int,ndelta,nlp,rmin,npts,logxir,gsdr,logner,dfer_arr)
+subroutine radfunctions_dens(config, model_args, arrays)
     ! In  : xe,rin,rnmax,eta_0,logxip,spin,h,honr,rlp,dcosdr,cosd,ndelta,rmin,npts
     ! logxir(xe),gsdr(xe)   logxi (ionization parameter) and gsd (source to disc blueshift) as a function of radius
     ! Out : logxir(1:xe), gsdr(1:xe), logner(1:xe)
+    use common_types
     use env_variables
+    use dyn_gr, only: ndelta, rlp, dcosdr, cosd, npts
+    use radial_grids, only: logxir, gsdr, logner, dfer_arr
     implicit none
-    integer         , intent(IN)   :: xe, ndelta, nlp, npts(nlp)
-    double precision, intent(IN)   :: rin,rmin,rnmax,eta_0,logxip,lognep,spin,h(nlp),honr,Gamma,dfer_arr(xe)
-    real                           :: gso(nlp)
-    double precision, intent(IN)   :: rlp(ndelta,nlp), dcosdr(ndelta,nlp), cosd(ndelta,nlp), contx_int(nlp)
+    type(t_config)         , intent(in)    :: config
+    type(t_model_arguments), intent(in)    :: model_args
+    type(t_arrays)         , intent(in)    :: arrays
+
+    real                           :: gso(model_args%nlp)
     double precision :: rlp_column(ndelta),dcosdr_column(ndelta),cosd_column(ndelta), dgsofac
-    double precision, intent(INOUT):: logxir(xe), gsdr(xe), logner(xe)
-    integer          :: i, kk, get_index, get_env_int, l, m, verbose
-    double precision :: rp, logxinorm, lognenorm,  mus, interper, newtex, mui, dinang, gsd(nlp), dglpfacthick
-    double precision :: xi_lp(xe,nlp), logxi_lp(xe,nlp), logxip_lp(nlp), xitot, xiraw, mylogne, mudisk, gsd_temp
+    integer          :: i, kk, get_index, get_env_int, l, m
+    double precision :: rp, logxinorm, lognenorm,  mus, interper, newtex, mui, dinang, gsd(model_args%nlp), dglpfacthick
+    double precision :: xi_lp(config%xe,model_args%nlp), logxi_lp(config%xe,model_args%nlp), logxip_lp(model_args%nlp)
+    double precision :: xitot, xiraw, mylogne, mudisk, gsd_temp
     double precision, allocatable :: rad(:)
 
     ! Set disk opening angle
-    mudisk   = honr / sqrt( honr**2 + 1.d0  )
+    mudisk   = model_args%honr / sqrt( model_args%honr**2 + 1.d0  )
     
-    allocate(rad(xe))
+    allocate(rad(config%xe))
     !Now calculate logxi itself
     ! The loop calculates the raw xi and raw n_e.
     ! This means they are without normalization: only to find the maximum and the minimum. Remember that the max of the ionisation is not the same as the minumim in the density because the flux depends on r
     !The loops calculates also the correction factor mui
 
     !TBD: include luminosity ratio between LPs 
-    do i = 1, xe        
-        rad(i) = (rnmax/rin)**(real(i-1) / real(xe))
-        rad(i) = rad(i) + (rnmax/rin)**(real(i) / real(xe))
-        rad(i) = rad(i) * rin * 0.5
+    do i = 1, config%xe
+        rad(i) = (config%rnmax/model_args%rin)**(real(i-1) / real(config%xe))
+        rad(i) = rad(i) + (config%rnmax/model_args%rin)**(real(i) / real(config%xe))
+        rad(i) = rad(i) * model_args%rin * 0.5
         !Initialize total ionization tracker
         xitot = 0. 
         gsd_temp = 0.
         !Now calculate the raw density (this matters only for high dens model reltransD)
-        logner(i) = adensity * mylogne(rad(i), rin)
-        do m=1,nlp
+        logner(i) = adensity * mylogne(rad(i), model_args%rin)
+        do m=1,model_args%nlp
             do l=1,ndelta
                 rlp_column(l) = rlp(l,m)
                 dcosdr_column(l) = dcosdr(l,m)
                 cosd_column(l) = cosd(l,m)
             end do    
-            gso(m) = real( dgsofac(spin,h(m)) )     
-            xi_lp(i,m) = xiraw(rad(i),spin,h(m),honr,rlp_column,dcosdr_column,ndelta,rmin,npts(m),mudisk,gsd(m))            
-            if (m .eq. 2) xi_lp(i,m) = eta_0*xi_lp(i,m)
+            gso(m) = real( dgsofac(model_args%a, model_args%h(m)) )
+            xi_lp(i,m) = xiraw(rad(i), model_args%a, model_args%h(m),         &
+                model_args%honr, rlp_column, dcosdr_column, ndelta,            &
+                config%rmin, npts(m), mudisk, gsd(m))
+            if (m .eq. 2) xi_lp(i,m) = model_args%eta_0 * xi_lp(i,m)
             !Calculate the incident angle for this bin
-            kk = get_index(rlp_column, ndelta, rad(i), rmin, npts(m))
+            kk = get_index(rlp_column, ndelta, rad(i), config%rmin, npts(m))
             mus = interper(rlp_column, cosd_column, ndelta, rad(i), kk)
-            if( kk .eq. npts(m) ) mus = newtex(rlp_column, cosd_column, ndelta, rad(i), h(m), honr, kk)
-            mui = dinang(spin, rad(i), h(m), mus)
+            if( kk .eq. npts(m) ) mus = newtex(rlp_column, cosd_column,        &
+                ndelta, rad(i), model_args%h(m), model_args%honr, kk)
+            mui = dinang(model_args%a, rad(i), model_args%h(m), mus)
             !Correction to account for the radial dependence of incident angle, and for the g factors
-            xi_lp(i,m) = xi_lp(i,m)/(sqrt(2.)*mui)*contx_int(m)*(gso(m))**(Gamma-2)  
+            xi_lp(i,m) = xi_lp(i,m) / (sqrt(2.) * mui)                        &
+                * arrays%contx_int(m) * (gso(m))**(model_args%Gamma - 2)
             xitot = xitot + xi_lp(i,m)
             gsd_temp = gsd_temp + gsd(m)*xi_lp(i,m)
         end do 
@@ -62,12 +69,13 @@ subroutine radfunctions_dens(verbose,xe,rin,rnmax,eta_0,logxip,lognep,spin,h,Gam
     !After the loop calculate the max and the min - ionization renormalized wrt to the first LP
     logxinorm = maxval(logxir)
     lognenorm = minval(logner)
-    logxir = logxir - (logxinorm - logxip) 
-    logner = logner - (lognenorm - lognep)    
+    logxir = logxir - (logxinorm - dble(model_args%logxi))
+    logner = logner - (lognenorm - dble(model_args%lognep))
     
-    do m=1,nlp 
-        do i=1,xe
-            logxi_lp(i,m) = log10(xi_lp(i,m)) - logner(i) - lognenorm - logxinorm + lognep + logxip        
+    do m=1,model_args%nlp
+        do i=1,config%xe
+            logxi_lp(i,m) = log10(xi_lp(i,m)) - logner(i) - lognenorm         &
+                - logxinorm + dble(model_args%lognep) + dble(model_args%logxi)
         end do
         logxip_lp(m) = max(maxval(logxi_lp(:,m)),0.)
     end do
@@ -77,10 +85,10 @@ subroutine radfunctions_dens(verbose,xe,rin,rnmax,eta_0,logxip,lognep,spin,h,Gam
     !note 1) we need to do this before the ionisation array is set to have a minimum of 0, in order
     !to recover the correct scaling of the emissivity at large radii
     !2) in order to correctly compare the dfer_arr array with the single LP case, it has to be renormalized by (1+eta_0)
-    if( verbose .gt. 1 ) then
+    if( config%verbose .gt. 1 ) then
         print*, "Peak ionisations from each LP: first " , logxip_lp(1), " second ", logxip_lp(2)
         open (unit = 27, file = 'Output/RadialScalings.dat', status='replace', action = 'write')
-            do i = 1, xe
+            do i = 1, config%xe
                 write(27,*) rad(i), logxir(i), gsdr(i), logxir(i)+logner(i), logxi_lp(i,1), logxi_lp(i,2), dfer_arr(i) 
             end do 
         close(27)    


### PR DESCRIPTION
Thanks for opening a PR!

## Checklist
- [x] I have HEASOFT installed and compiled
- [x] I compiled reltrans
- [x] I have run the test suite (pytest)

## Description of this PR
This PR addresses issue #90 and its sub-issue #99.

This change refactors `radfunctions_dens` to use the grouped derived-type arguments `config`, `model_args`, and `arrays` instead of the previous long positional argument list. The corresponding call in `genreltrans` was updated, and the include order in `header.h` was adjusted so `common.f90` is available before the refactored routine.

The goal is to reduce the size of the call interface and keep this routine consistent with the ongoing issue #90 refactor work.

## Anything important?
Moved `include 'subroutines/common.f90'` in `header.h` .