### PR TITLE
refactor - `radfuncs_dist`

### DIFF
--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -477,11 +477,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
     if (dset .eq. 0) then
        call radfunctions_dens(config, model_args, arrays)
     else
-       call radfuncs_dist(config%xe, model_args%rin, rnmax,model_args%b1,     &
-            model_args%b2, model_args%qboost, fcons,                           &
-            & dble(model_args%lognep), model_args%a, model_args%h(1),          &
-            model_args%honr, rlp, dcosdr, cosd, ndelta, config%rmin,npts(1),   &
-            & logxir, gsdr, logner, pnorm)
+       call radfuncs_dist(config, model_args, fcons)
      end if
 
      ! do this for each lamp post, then find some sort of weird average?

--- a/subroutines/radial_profiles/radfuncs_dist.f90
+++ b/subroutines/radial_profiles/radfuncs_dist.f90
@@ -1,70 +1,69 @@
 !-----------------------------------------------------------------------
-subroutine radfuncs_dist(xe, rin, rnmax, b1, b2, qboost, fcons,&
-     & lognep, spin, h, honr, rlp, dcosdr, cosd, ndelta, rmin, npts,&
-     & logxieff, gsdr, logner, pnorm)
+subroutine radfuncs_dist(config, model_args, fcons)
 ! Calculates ionization parameter, g-factor and disc density as a
 ! function of disc radius. This subroutine is only called for rtdist
 !
-! In  : xe,rin,rnmax,logxip,spin,h,honr,rlp,dcosdr,cosd,ndelta,rmin,npts
+! In  : config, model_args, fcons
 ! Out :
-! logxir(1:xe) -- Effective ionisation as a function of r
-! gsdr(1:xe)   -- Source-to-disc blueshift as a function of r
-! logner(1:xe) -- Log10 of electron density as a function of r
+! logxir(1:xe) -- Effective ionisation as a function of r (via radial_grids)
+! gsdr(1:xe)   -- Source-to-disc blueshift as a function of r (via radial_grids)
+! logner(1:xe) -- Log10 of electron density as a function of r (via radial_grids)
 !note: this does not work with multiple lamposts for now
 
+  use common_types
+  use dyn_gr, only: ndelta, rlp, dcosdr, cosd, npts
+  use radial_grids, only: logxir, gsdr, logner, pnorm
   use env_variables
   implicit none
-  integer         , intent(IN)   :: xe, ndelta, npts 
-  double precision, intent(IN)   :: rin, rmin, rnmax, b1, b2, qboost
-  double precision, intent(IN)   :: fcons, lognep, spin, h, honr
-  double precision, intent(IN)   :: rlp(ndelta), dcosdr(ndelta), cosd(ndelta)
-  double precision, intent(INOUT):: logxieff(xe), gsdr(xe), logner(xe)
+  type(t_config),          intent(in) :: config
+  type(t_model_arguments), intent(in) :: model_args
+  double precision,        intent(in) :: fcons
   integer          :: i, kk, get_index, get_env_int, verbose
-  double precision :: pnorm,re,re1(xe),zA_logne,cosfac,mus,interper,newtex,mudisk
+  double precision :: re,re1(config%xe),zA_logne,cosfac,mus,interper,newtex,mudisk
   double precision, parameter :: pi = acos(-1.d0)
-  double precision :: ptf,pfunc_raw,gsd,dglpfacthick,eps_bol,Fx(xe),logxir(xe),mui,dinang
+  double precision :: ptf,pfunc_raw,gsd,dglpfacthick,eps_bol,Fx(config%xe),logxir_raw(config%xe),mui,dinang
   double precision :: dareafac,lximax
 
 ! Set disk opening angle
-  mudisk   = honr / sqrt( honr**2 + 1.d0  )
+  mudisk   = model_args%honr / sqrt( model_args%honr**2 + 1.d0  )
 ! Now loop through xe radial bins
-  do i = 1,xe
+  do i = 1,config%xe
      !Radius
-     re     = (rnmax/rin)**(real(i-1) / real(xe))
-     re     = re + (rnmax/rin)**(real(i) / real(xe))
-     re     = re * rin * 0.5
+     re     = (config%rnmax/model_args%rin)**(real(i-1) / real(config%xe))
+     re     = re + (config%rnmax/model_args%rin)**(real(i) / real(config%xe))
+     re     = re * model_args%rin * 0.5
      re1(i) = re
      !Density
-     logner(i) = zA_logne(re,rin,lognep)     
+     logner(i) = zA_logne(re,model_args%rin,dble(model_args%lognep))
      !Interpolate functions from rpl grid
-     kk     = get_index(rlp,ndelta,re,rmin,npts)
+     kk     = get_index(rlp,ndelta,re,config%rmin,npts(1))
      cosfac = interper(rlp,dcosdr,ndelta,re,kk)
      mus    = interper(rlp,cosd  ,ndelta,re,kk)
-     if( kk .eq. npts )then !Extrapolation onto Newtonian grid
-        cosfac = newtex(rlp,dcosdr,ndelta,re,h,honr,kk)
-        mus    = newtex(rlp,cosd  ,ndelta,re,h,honr,kk)
+     if( kk .eq. npts(1) )then !Extrapolation onto Newtonian grid
+        cosfac = newtex(rlp,dcosdr,ndelta,re,model_args%h(1),model_args%honr,kk)
+        mus    = newtex(rlp,cosd  ,ndelta,re,model_args%h(1),model_args%honr,kk)
      end if
      !Calculate 13.6 eV - 13.6 keV illuminating flux
-     ptf     = pnorm * pfunc_raw(-mus,b1,b2,qboost)
-     gsd     = dglpfacthick(re,spin,h,mudisk)
-     !gsd     = dglpfac(re,spin,h)
+     ptf     = pnorm * pfunc_raw(-mus,model_args%b1,model_args%b2,model_args%qboost)
+     gsd     = dglpfacthick(re,model_args%a,model_args%h(1),mudisk)
+     !gsd     = dglpfac(re,model_args%a,model_args%h(1))
      gsdr(i) = gsd
      eps_bol = gsd**2 * 2.0 * pi * ptf
-     eps_bol = eps_bol * cosfac / dareafac(re,spin)
+     eps_bol = eps_bol * cosfac / dareafac(re,model_args%a)
      Fx(i)   = fcons * eps_bol
      !Calculate logxi(r)
-     logxir(i) = log10( 4.0 * pi * Fx(i) ) - logner(i)
+     logxir_raw(i) = log10( 4.0 * pi * Fx(i) ) - logner(i)
      !Now adjust to effective ionization parameter
-     mui         = dinang(spin, re, h, mus)
-     logxieff(i) = logxir(i) - 0.1505 - log10(mui)     
-!     write(188,*)re,logxir(i),logxieff(i)
-     
+     mui       = dinang(model_args%a, re, model_args%h(1), mus)
+     logxir(i) = logxir_raw(i) - 0.1505 - log10(mui)
+!     write(188,*)re,logxir_raw(i),logxir(i)
+
   end do
 !  write(188,*)"no no"
-  
+
 !check max and min for both ionisation and density
-  logxieff = max( logxieff , 0.d0  )
-  logxieff = min( logxieff , 4.7d0 )
+  logxir = max( logxir , 0.d0  )
+  logxir = min( logxir , 4.7d0 )
   ! logner   = max( logner , 15.d0  )
   ! logner   = min( logner , 22.d0 )
   !...no need to enforce limits on logne since this is done in myreflect()
@@ -74,14 +73,14 @@ subroutine radfuncs_dist(xe, rin, rnmax, b1, b2, qboost, fcons,&
   if( verbose .gt. 2 )then
      !Write out logxir for plots
      lximax = -huge(lximax)
-     do i = 1,xe
-        write(188,*)re1(i),Fx(i),logxir(i)
-        lximax = max( lximax , logxieff(i) )
+     do i = 1,config%xe
+        write(188,*)re1(i),Fx(i),logxir_raw(i)
+        lximax = max( lximax , logxir(i) )
      end do
      write(188,*)"no no"
      write(*,*)"MAX LOGXIeff = ",lximax
   end if
-  
+
   return
-end subroutine radfuncs_dist  
+end subroutine radfuncs_dist
 !-----------------------------------------------------------------------


### PR DESCRIPTION
Thanks for opening a PR!

## Checklist
- [x] I have HEASOFT installed and compiled
- [x] I compiled reltrans
- [x] I have run the test suite (pytest)

## Description of this PR
This PR addresses issue #90, subissue #100.

This change refactors `radfuncs_dist` to use grouped arguments through the derived types `config` and `model_args`, with `fcons` kept as a separate scalar input. The long positional argument list was removed from both the subroutine definition and its call site in `genreltrans`.

Inside `radfuncs_dist`, values that belong to the shared refactoring types are now accessed directly through `config%...` and `model_args%...`, while module-level arrays continue to be accessed through `dyn_gr` and `radial_grids`. I also renamed the local intermediate `logxir` array to `logxir_raw` to avoid clashing with the module-level output array.

## Anything important?
I changed `logxir` → `logxir_raw` to avoid a clash with the module output array.