### PR TITLE
update reltrans version patch

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+describe-name: $Format:%(describe:tags=true)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt export-subst

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Build debug reltrans
         run: |
           make DEBUG=1

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ ROOTDIR := .
 HEADAS_LIB := ${HEADAS}/lib
 HEADAS_INCLUDE := ${HEADAS}/include
 
+# Derive the version from the most recent git tag, or from .git_archival.txt
+# (automatically populated by git archive / GitHub release tarballs).
+VERSION := $(shell git fetch --tags --quiet 2>/dev/null; git describe --tags --always 2>/dev/null || sed -n 's/describe-name: *//p' .git_archival.txt 2>/dev/null | grep -v 'Format:')
+
 # These may be set when invoking `make`, such as `make DEBUG=1 SANITIZE=1`.
 # The `DEBUG` option compiles a debug build of reltrans (see below).
 DEBUG = 0
@@ -22,7 +26,8 @@ ALL_RELTRANS_SOURCE_FILES = $(shell find $(ROOTDIR)/subroutines -name '*.f90')
 
 CFLAGS := -fno-omit-frame-pointer
 
-FFLAGS := -DHAVE_INLINE -fPIC -fno-automatic -fno-second-underscore \
+FFLAGS := -cpp -DHAVE_INLINE \
+		  -fPIC -fno-automatic -fno-second-underscore \
 		  -fno-omit-frame-pointer \
 		  -fopenmp \
 		  -I$(BUILD)/include \
@@ -30,6 +35,11 @@ FFLAGS := -DHAVE_INLINE -fPIC -fno-automatic -fno-second-underscore \
 		  -I$(HEADAS_INCLUDE)/fftw \
 		  -J$(BUILD)/cache \
 		  -I$(BUILD)/cache
+
+# Only pass the version macro if git found a tag
+ifneq ($(VERSION),)
+FFLAGS += -DRELTRANS_VERSION='"$(VERSION)"'
+endif
 
 LDFLAGS := -lXSFunctions -lXSModel -lfftw3 -lcfitsio \
 		   -L$(BUILD)/lib -L$(HEADAS_LIB)

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ HEADAS_INCLUDE := ${HEADAS}/include
 # Derive the version from the most recent git tag, or from .git_archival.txt
 # (automatically populated by git archive / GitHub release tarballs).
 VERSION := $(shell git fetch --tags --quiet 2>/dev/null; git describe --tags --always 2>/dev/null || sed -n 's/describe-name: *//p' .git_archival.txt 2>/dev/null | grep -v 'Format:')
+VERSION := $(shell echo '$(VERSION)' | sed 's/-.*//')
+
 
 # These may be set when invoking `make`, such as `make DEBUG=1 SANITIZE=1`.
 # The `DEBUG` option compiles a debug build of reltrans (see below).

--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -33,8 +33,9 @@ contains
     end subroutine setup_global_arrays
 
     subroutine print_header()
+        use reltrans_version_mod
         write(*,*)"----------------------------------------------------"
-        write(*,*)"This is RELTRANS v1.0.0: a transfer function model for"
+        write(*,*)"This is RELTRANS " // reltrans_version // ": a transfer function model for"
         write(*,*)"X-ray reverberation mapping."
         write(*,*)"Please cite Ingram et al (2019) MNRAS 488 p324-347, "
         write(*,*)"Mastroserio et al (2021) MNRAS 507 p55-73, and "

--- a/wrappers.f90
+++ b/wrappers.f90
@@ -9,6 +9,15 @@
 !CURRENT BRANCH
 ! This branch is adding the multiple flavours to the reltrans model
 
+! Version Patch(Automated by Makefile)
+#ifndef RELTRANS_VERSION
+#define RELTRANS_VERSION "unknown"
+#endif
+module reltrans_version_mod
+    implicit none
+    character(len=*), parameter :: reltrans_version = RELTRANS_VERSION
+end module reltrans_version_mod
+
 include 'subroutines/amodules.f90'
 include 'subroutines/header.h'
           


### PR DESCRIPTION
## Checklist
- [x] I have HEASOFT installed and compiled
- [x] I compiled reltrans
- [x] I have run the test suite (pytest)

## Description of this PR

This PR addresses the hardcoded version string in reltrans. Previously, `print_header()` always printed `v1.0.0` regardless of the actual release version.

This PR addresses issue #84

### Changes

- **[Makefile](cci:7://file:///k:/Gsoc2026/reltrans/Makefile:0:0-0:0)**: Added a [VERSION](cci:7://file:///k:/Gsoc2026/reltrans/VERSION:0:0-0:0) variable that derives the version from `git describe --tags`. For release tarballs (where git is unavailable), it falls back to parsing [.git_archival.txt](cci:7://file:///k:/Gsoc2026/reltrans/.git_archival.txt:0:0-0:0), which is automatically populated by `git archive`.
- **[wrappers.f90](cci:7://file:///k:/Gsoc2026/reltrans/wrappers.f90:0:0-0:0)**: Added a small `reltrans_version_mod` module that captures the compile-time `-DRELTRANS_VERSION` macro as a Fortran character parameter. This is necessary because [wrappers.f90](cci:7://file:///k:/Gsoc2026/reltrans/wrappers.f90:0:0-0:0) is the only file processed by the C preprocessor — included files like [genreltrans.f90](cci:7://file:///k:/Gsoc2026/reltrans/subroutines/genreltrans.f90:0:0-0:0) are handled by the Fortran parser after cpp has finished.
- **[subroutines/genreltrans.f90](cci:7://file:///k:/Gsoc2026/reltrans/subroutines/genreltrans.f90:0:0-0:0)**: `print_header()` now uses `reltrans_version_mod` to print the dynamically injected version string.
- **[.gitattributes](cci:7://file:///k:/Gsoc2026/reltrans/.gitattributes:0:0-0:0) + [.git_archival.txt](cci:7://file:///k:/Gsoc2026/reltrans/.git_archival.txt:0:0-0:0)**: Enables `export-subst` so that `git archive` (used by GitHub to create release tarballs) automatically substitutes the version into [.git_archival.txt](cci:7://file:///k:/Gsoc2026/reltrans/.git_archival.txt:0:0-0:0). This ensures HEASoft users who download release tarballs see the correct version without needing git.
- **[.github/workflows/test.yml](cci:7://file:///k:/Gsoc2026/reltrans/.github/workflows/test.yml:0:0-0:0)**: Added `fetch-depth: 0` to the checkout step so CI has access to git tags.

### Version resolution priority

1. `git describe --tags` (developers, CI)
2. [.git_archival.txt](cci:7://file:///k:/Gsoc2026/reltrans/.git_archival.txt:0:0-0:0) (release tarball users / HEASoft)
3. `"unknown"` (fallback when neither is available)

output:
<img width="629" height="159" alt="image" src="https://github.com/user-attachments/assets/285d2d91-f296-4043-92aa-f8153972276c" />


## Anything important?
 The user must have git inside the `Heasoft ' and 'Docker` so that they can run this function smoothly.
 The user needs to install git using 
 ```git
 apt update && apt install -y git
```
and set it for global, then run `make`
```git
git config --global --add safe.directory /workspace
```
I will say we need to trim and take care of the printing outputs