### PR TITLE
refactor: `rest_frame`

### DIFF
--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -218,28 +218,23 @@ contains
                 thetae = acos(mue) * 180.0 / real(pi)
                 if (config%me .eq. 1) thetae = real(model_args%inc)
                 ! Call restframe reflection model
-                call rest_frame(arrays%earx, nex, Gamma0, model_args%Afe,      &
-                     logne, Cutoff_0, logxi0, thetae, model_args%Cp,           &
-                     photarx)
+                call rest_frame(model_args, arrays, Gamma0, logne,             &
+                    Cutoff_0, logxi0, thetae, photarx)
                 ! NON LINEAR EFFECTS
                 if (config%DC .eq. 0) then
                    ! Gamma variations
                    logxi1 = logxi0 + ionvariation * dlogxi1
-                   call rest_frame(arrays%earx, nex, Gamma1, model_args%Afe,   &
-                        logne, Cutoff_0, logxi1, thetae, model_args%Cp,        &
-                        photarx_1)
+                   call rest_frame(model_args, arrays, Gamma1, logne,          &
+                       Cutoff_0, logxi1, thetae, photarx_1)
                    logxi2 = logxi0 + ionvariation * dlogxi2
-                   call rest_frame(arrays%earx, nex, Gamma2, model_args%Afe,   &
-                        logne, Cutoff_0, logxi2, thetae, model_args%Cp,        &
-                        photarx_2)
+                   call rest_frame(model_args, arrays, Gamma2, logne,          &
+                       Cutoff_0, logxi2, thetae, photarx_2)
                    photarx_delta = (photarx_2 - photarx_1)/(Gamma2-Gamma1)
                    ! xi variations
-                   call rest_frame(arrays%earx, nex, Gamma0, model_args%Afe,   &
-                        logne, Cutoff_0, logxi1, thetae, model_args%Cp,        &
-                        photarx_1)
-                   call rest_frame(arrays%earx, nex, Gamma0, model_args%Afe,   &
-                        logne, Cutoff_0, logxi2, thetae, model_args%Cp,        &
-                        photarx_2)
+                   call rest_frame(model_args, arrays, Gamma0, logne,          &
+                       Cutoff_0, logxi1, thetae, photarx_1)
+                   call rest_frame(model_args, arrays, Gamma0, logne,          &
+                       Cutoff_0, logxi2, thetae, photarx_2)
                    photarx_dlogxi = 0.434294481 * (photarx_2 - photarx_1) / (dlogxi2-dlogxi1) !pre-factor is 1/ln10
                 end if
                 ! Multiply by E^{Gamma-1} to make less steep

--- a/subroutines/rest_frame_reflection/rest_frame.f90
+++ b/subroutines/rest_frame_reflection/rest_frame.f90
@@ -1,61 +1,60 @@
 !-----------------------------------------------------------------------
-subroutine rest_frame(ear,ne,Gamma,Afe,logne,Cutoff,logxi,thetae,Cp,photar)
+subroutine rest_frame(model_args, arrays, Gamma, logne, Cutoff, logxi,         &
+    thetae, photar)
 !
-!  Cp : chooses reflection model
-!      -1 xillver      1e15 density and powerlaw illumination  
-!       1 xillverD     high density and powerlaw illumination 
+!  model_args%Cp : chooses reflection model
+!      -1 xillver      1e15 density and powerlaw illumination
+!       1 xillverD     high density and powerlaw illumination
 !       2 xillverDCp   high density and nthcomp  illumination
 !       0 reflionxDCp  reflionx high density and nthcomp  illumination
 !
-!       The first 2 have the same number of parameters xillpar(6), 
+!       The first 2 have the same number of parameters xillpar(6),
 !       in the first one Cutoff is a parameter (either energy or temperature)
 !       and the density is fixed to 10^15
-!       in the second one the density is a parameter and Cutoff is fixed to 300 keV 
-!       The Cp = 2 has one more parameter both Cutoff and density are parameters
+!       in the second one the density is a parameter and Cutoff is fixed to
+!       300 keV
+!       The Cp = 2 has one more parameter both Cutoff and density are
+!       parameters
 
 !       Last change: Gullo - 2022 Oct
 
+   use common_types
+   use conv_mod, only: nex
    implicit none
-   integer, intent(in) :: ne, Cp
-   real, intent(in)    :: ear(0:ne), Gamma, Afe, logne, Cutoff, logxi, thetae
-   real, intent(out)   :: photar(ne)
+   type(t_model_arguments), intent(in) :: model_args
+   type(t_arrays),          intent(in) :: arrays
+   real, intent(in)    :: Gamma, logne, Cutoff, logxi, thetae
+   real, intent(out)   :: photar(nex)
    integer, parameter  :: dim = 6, dimCp = 8
    real                :: xillpar(dim), xillparDCp(dimCp)
-   ! integer :: j 
-   
-   if( Cp .ne. 0 )then
-      !The model is a xillver model
-   !   !Set density limits
-   !   lognex = min(logne,22.0)
-      !Fill parameter arrays
-      xillpar(1) = Gamma     !Power law index
-      xillpar(2) = Afe       !Iron abundance
-      xillpar(3) = logxi     !ionization par
-      xillpar(4) = Cutoff      !Ecut or kTe
-      if( Cp .eq. 1 )then
-         xillpar(4) = logne !logne
-      end if
-      xillpar(5) = thetae    !emission angle
-      xillpar(6) = 0.0     !redshift!this parameters was here when we called relxill to get xillver
-      xillparDCp(1) = Gamma  !photon index
-      xillparDCp(2) = Afe    !Afe
-      xillparDCp(3) = logxi  !ionization par
-      xillparDCp(4) = Cutoff   !kTe
-      xillparDCp(5) = logne !logne
-      xillparDCp(6) = thetae !emission angle
-      xillparDCp(7) = 0.0  !redshift !this parameters was here when we called relxill to get xillver
 
-      ! write(*,*) 'logxi in rest frame ', logxi, xillparDCp(3)
-      ! write(*,*) 'logne in rest frame ', logne, xillparDCp(5)
-      call get_xillver(ear, ne, dim, dimCp, xillpar, xillparDCp, Cp, photar)
-      ! photar = photar / 10**(logxi + logne - 15) !this factor is needed to match the normalisation with the first versions of reltrans
-      ! write(*,*) 'xillver normalisation factor 10**(logxi + logne - 15)', 10**(logxi + logne - 15)
+   if( model_args%Cp .ne. 0 )then
+      !The model is a xillver model
+      !Fill parameter arrays
+      xillpar(1) = Gamma                !Power law index
+      xillpar(2) = model_args%Afe       !Iron abundance
+      xillpar(3) = logxi                !ionization par
+      xillpar(4) = Cutoff               !Ecut or kTe
+      if( model_args%Cp .eq. 1 )then
+         xillpar(4) = logne             !logne
+      end if
+      xillpar(5) = thetae               !emission angle
+      xillpar(6) = 0.0                  !redshift
+      xillparDCp(1) = Gamma             !photon index
+      xillparDCp(2) = model_args%Afe    !Afe
+      xillparDCp(3) = logxi             !ionization par
+      xillparDCp(4) = Cutoff            !kTe
+      xillparDCp(5) = logne             !logne
+      xillparDCp(6) = thetae            !emission angle
+      xillparDCp(7) = 0.0               !redshift
+
+      call get_xillver(arrays%earx, nex, dim, dimCp, xillpar, xillparDCp,      &
+          model_args%Cp, photar)
 
    else
       !The model is reflionx
-      !Set density limits
-   !   lognex = min(logne,22.0)
-      call normreflionx(ear,ne,Gamma,Afe,logne,Cutoff,logxi,thetae,photar)
+      call normreflionx(arrays%earx, nex, Gamma, model_args%Afe, logne,        &
+          Cutoff, logxi, thetae, photar)
    end if
 
    return


### PR DESCRIPTION
Thanks for opening a PR!

## Checklist
- [x] I have HEASOFT installed and compiled
- [x] I compiled reltrans
- [x] I have run the test suite (pytest)

## Description of this PR
This PR addresses issue #90, subissue #107.

This change refactors `rest_frame` to use grouped arguments through the derived types `model_args` and `arrays`, while keeping `Gamma`, `logne`, `Cutoff`, `logxi`, `thetae`, and `photar` as separate arguments because they vary per call.

The long positional argument list was removed from the `rest_frame` subroutine definition and from its call sites in `genreltrans.f90`. Inside `rest_frame`, values such as `Afe` and `Cp` are now accessed through `model_args`, and the internal energy grid is accessed through `arrays%earx`.

