### PR TITLE
refactor: `conv_one_FFT/conv_one_FFTw `take derived types

### DIFF
--- a/subroutines/amodules.f90
+++ b/subroutines/amodules.f90
@@ -218,59 +218,6 @@ contains
     plan2 = fftw_plan_dft_c2r_1d(nex_conv, in_conv, out_conv, flags)
   end subroutine init_fftw_allconv
 
-  subroutine conv_one_FFTw(dyn,earx,Gamma,photarx,reline,imline,ReW_conv,ImW_conv,DC,nlp)
-    implicit none
-    integer, intent(in) :: DC, nlp 
-    real                :: dyn
-    real, intent(in)    :: photarx(nex), earx(0:nex), Gamma
-    real, intent(in)    :: reline(nlp,nex), imline(nlp,nex)
-    real, intent(inout) :: ReW_conv(nlp,nex), ImW_conv(nlp,nex)
-    complex :: conv(nec),padFT_photarx(nec)
-    complex :: padFT_reline(nec),  padFT_imline(nec)            
-    integer :: m, i
-    real    :: photmax, depad_conv(nex), E
-    
-    do m=1,nlp  
-       if (DC .eq. 1 ) then
-          ! call padding4FT(photarx,padFT_photarx)
-          call padding4FT_xillver(photarx,padFT_photarx)
-
-          call padding4FT(reline(m,:),padFT_reline)                        
-
-          conv = (padFT_photarx * padFT_reline) * nexm1
-          call de_paddingFT(dyn, conv, depad_conv)
-
-          do i = 1,nex
-             E             = 0.5 * ( earx(i) + earx(i-1) )
-             ReW_conv(m,i) = ReW_conv(m,i) + depad_conv(i) * E**(1-Gamma)
-          end do
-                   
-       else 
-          call padding4FT(photarx       , padFT_photarx)        
-          call padding4FT(reline(m,:),padFT_reline)
-          call padding4FT(imline(m,:),padFT_imline)
-
-          conv = (padFT_photarx * padFT_reline) * nexm1
-          call de_paddingFT(dyn, conv, depad_conv)
-
-          do i = 1,nex
-             E             = 0.5 * ( earx(i) + earx(i-1) )
-             ReW_conv(m,i) = ReW_conv(m,i) + depad_conv(i) * E**(1-Gamma)
-          end do
-
-          conv = (padFT_photarx * padFT_imline) * nexm1
-          call de_paddingFT(dyn, conv, depad_conv)
-
-          do i = 1,nex
-             E             = 0.5 * ( earx(i) + earx(i-1) )
-             ImW_conv(m,i) = ImW_conv(m,i) + depad_conv(i) * E**(1-Gamma)
-          end do
-          
-       endif
-    end do
-
-  end subroutine conv_one_FFTw
-
   subroutine padding4FT(line, padFT_line)
     implicit none 
     real           , intent(in)  :: line(nex)

--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -154,7 +154,7 @@ contains
     end subroutine config_frequency
 
     subroutine do_convolutions(config, model_args, arrays)
-        use conv_mod, only: nex, conv_one_FFTw
+        use conv_mod, only: nex
         use gr_continuum, only: gso, lens
         use radial_grids, only: logner, gsdr, logxir
         type(t_config), intent(in) :: config
@@ -270,44 +270,42 @@ contains
                    ! not at their callsites
                    ! Do the convolution (involves multiplying by E^{1-Gamma})
                    if (config%test) then
-                      call conv_one_FFT(dyn, arrays%earx, Gamma0, Hx,          &
-                           reline_w0, imline_w0, arrays%ReW0(:, :, j),         &
-                           arrays%ImW0(:, :, j), config%DC, model_args%nlp)
+                      call conv_one_FFT(config, model_args, dyn, arrays%earx,  &
+                           Gamma0, Hx, reline_w0, imline_w0,                   &
+                           arrays%ReW0(:, :, j), arrays%ImW0(:, :, j))
                       if (config%DC .eq. 0 .and. config%refvar .eq. 1) then
-                         call conv_one_FFT(dyn, arrays%earx, Gamma0, Hx,       &
-                              reline_w1, imline_w1, arrays%ReW1(:, :, j),      &
-                              arrays%ImW1(:, :, j), config%DC,                 &
-                              model_args%nlp)
-                         call conv_one_FFT(dyn, arrays%earx, Gamma0,           &
-                              Hx_delta, reline_w2, imline_w2, arrays%ReW2(:,   &
-                              :, j), arrays%ImW2(:, :, j), config%DC,          &
-                              model_args%nlp)
+                         call conv_one_FFT(config, model_args, dyn,            &
+                              arrays%earx, Gamma0, Hx, reline_w1, imline_w1,   &
+                              arrays%ReW1(:, :, j), arrays%ImW1(:, :, j))
+                         call conv_one_FFT(config, model_args, dyn,            &
+                              arrays%earx, Gamma0, Hx_delta, reline_w2,        &
+                              imline_w2, arrays%ReW2(:, :, j),                 &
+                              arrays%ImW2(:, :, j))
                       end if
                       if (config%DC .eq. 0 .and. config%ionvar .eq. 1) then
-                         call conv_one_FFT(dyn, arrays%earx, Gamma0,           &
-                              Hx_dlogxi, reline_w3, imline_w3,                 &
-                              arrays%ReW3(:, :, j), arrays%ImW3(:, :, j),      &
-                              config%DC, model_args%nlp)
+                         call conv_one_FFT(config, model_args, dyn,            &
+                              arrays%earx, Gamma0, Hx_dlogxi, reline_w3,       &
+                              imline_w3, arrays%ReW3(:, :, j),                 &
+                              arrays%ImW3(:, :, j))
                       end if
                    else
-                      call conv_one_FFTw(dyn, arrays%earx, Gamma0, Hx,         &
-                           reline_w0, imline_w0, arrays%ReW0(:, :, j),         &
-                           arrays%ImW0(:, :, j), config%DC, model_args%nlp)
+                      call conv_one_FFTw(config, model_args, dyn, arrays%earx, &
+                           Gamma0, Hx, reline_w0, imline_w0,                   &
+                           arrays%ReW0(:, :, j), arrays%ImW0(:, :, j))
                       if (config%DC .eq. 0 .and. config%refvar .eq. 1) then
-                         call conv_one_FFTw(dyn, arrays%earx, Gamma0, Hx,      &
-                              reline_w1, imline_w1, arrays%ReW1(:, :, j),      &
-                              arrays%ImW1(:, :, j), config%DC,                 &
-                              model_args%nlp)
-                         call conv_one_FFTw(dyn, arrays%earx, Gamma0,          &
-                              Hx_delta, reline_w2, imline_w2, arrays%ReW2(:,   &
-                              :, j), arrays%ImW2(:, :, j), config%DC,          &
-                              model_args%nlp)
+                         call conv_one_FFTw(config, model_args, dyn,           &
+                              arrays%earx, Gamma0, Hx, reline_w1, imline_w1,   &
+                              arrays%ReW1(:, :, j), arrays%ImW1(:, :, j))
+                         call conv_one_FFTw(config, model_args, dyn,           &
+                              arrays%earx, Gamma0, Hx_delta, reline_w2,        &
+                              imline_w2, arrays%ReW2(:, :, j),                 &
+                              arrays%ImW2(:, :, j))
                       end if
                       if (config%DC .eq. 0 .and. config%ionvar .eq. 1) then
-                         call conv_one_FFTw(dyn, arrays%earx, Gamma0,          &
-                              Hx_dlogxi, reline_w3, imline_w3,                 &
-                              arrays%ReW3(:, :, j), arrays%ImW3(:, :, j),      &
-                              config%DC, model_args%nlp)
+                         call conv_one_FFTw(config, model_args, dyn,           &
+                              arrays%earx, Gamma0, Hx_dlogxi, reline_w3,       &
+                              imline_w3, arrays%ReW3(:, :, j),                 &
+                              arrays%ImW3(:, :, j))
                       end if
                    endif
                 end do

--- a/subroutines/header.h
+++ b/subroutines/header.h
@@ -4,6 +4,7 @@ include 'subroutines/continuum/getcont.f90'
 include 'subroutines/continuum/init_cont.f90'
 
 include 'subroutines/utils/conv_one_FFT.f90'
+include 'subroutines/utils/conv_one_FFTw.f90'
 include 'subroutines/utils/crebin.f90'
 include 'subroutines/utils/four1.f90'
 include 'subroutines/utils/four1_real.f90'

--- a/subroutines/utils/conv_one_FFT.f90
+++ b/subroutines/utils/conv_one_FFT.f90
@@ -1,19 +1,22 @@
-  subroutine conv_one_FFT(dyn,earx,Gamma,photarx,reline,imline,ReW_conv,ImW_conv,DC,nlp)
+  subroutine conv_one_FFT(config, model_args, dyn, earx, Gamma, photarx,       &
+       reline, imline, ReW_conv, ImW_conv)
     use conv_mod
+    use common_types
     implicit none
-    integer, intent(in) :: DC, nlp 
+    type(t_config),          intent(in)    :: config
+    type(t_model_arguments), intent(in)    :: model_args
     real                :: dyn
     real, intent(in)    :: photarx(nex),earx(nex),Gamma
-    real, intent(in)    :: reline(nlp,nex), imline(nlp,nex)
-    real, intent(inout) :: ReW_conv(nlp,nex), ImW_conv(nlp,nex)
+    real, intent(in)    :: reline(model_args%nlp,nex), imline(model_args%nlp,nex)
+    real, intent(inout) :: ReW_conv(model_args%nlp,nex), ImW_conv(model_args%nlp,nex)
     complex :: FTphotarx(nex_conv), FTreline(nex_conv), FTimline(nex_conv)
     complex :: FTreconv(4*nex),FTimconv(4*nex)
     integer :: m, i
     real    :: photmax, depad_conv(nex), E
     ! real, parameter :: nexm1 = 1. / real(nex_conv)
     
-    do m=1,nlp  
-       if (DC .eq. 1 ) then
+    do m=1,model_args%nlp
+       if (config%DC .eq. 1 ) then
           call pad4FFT(nex, photarx, FTphotarx)
           call pad4FFT(nex, reline(m,:), FTreline)
           FTreconv = (FTreline * FTphotarx) !* nexm1

--- a/subroutines/utils/conv_one_FFTw.f90
+++ b/subroutines/utils/conv_one_FFTw.f90
@@ -1,0 +1,60 @@
+  ! FFTW-based convolution of the reflection kernels with the restframe
+  ! spectrum. Lives outside conv_mod (as a free subroutine) so that it can
+  ! `use common_types`: conv_mod is a dependency of common_types, so a
+  ! procedure inside conv_mod cannot itself use the derived types.
+  subroutine conv_one_FFTw(config, model_args, dyn, earx, Gamma, photarx,      &
+       reline, imline, ReW_conv, ImW_conv)
+    use conv_mod
+    use common_types
+    implicit none
+    type(t_config),          intent(in)    :: config
+    type(t_model_arguments), intent(in)    :: model_args
+    real                :: dyn
+    real, intent(in)    :: photarx(nex), earx(0:nex), Gamma
+    real, intent(in)    :: reline(model_args%nlp,nex), imline(model_args%nlp,nex)
+    real, intent(inout) :: ReW_conv(model_args%nlp,nex), ImW_conv(model_args%nlp,nex)
+    complex :: conv(nec),padFT_photarx(nec)
+    complex :: padFT_reline(nec),  padFT_imline(nec)
+    integer :: m, i
+    real    :: photmax, depad_conv(nex), E
+
+    do m=1,model_args%nlp
+       if (config%DC .eq. 1 ) then
+          ! call padding4FT(photarx,padFT_photarx)
+          call padding4FT_xillver(photarx,padFT_photarx)
+
+          call padding4FT(reline(m,:),padFT_reline)
+
+          conv = (padFT_photarx * padFT_reline) * nexm1
+          call de_paddingFT(dyn, conv, depad_conv)
+
+          do i = 1,nex
+             E             = 0.5 * ( earx(i) + earx(i-1) )
+             ReW_conv(m,i) = ReW_conv(m,i) + depad_conv(i) * E**(1-Gamma)
+          end do
+
+       else
+          call padding4FT(photarx       , padFT_photarx)
+          call padding4FT(reline(m,:),padFT_reline)
+          call padding4FT(imline(m,:),padFT_imline)
+
+          conv = (padFT_photarx * padFT_reline) * nexm1
+          call de_paddingFT(dyn, conv, depad_conv)
+
+          do i = 1,nex
+             E             = 0.5 * ( earx(i) + earx(i-1) )
+             ReW_conv(m,i) = ReW_conv(m,i) + depad_conv(i) * E**(1-Gamma)
+          end do
+
+          conv = (padFT_photarx * padFT_imline) * nexm1
+          call de_paddingFT(dyn, conv, depad_conv)
+
+          do i = 1,nex
+             E             = 0.5 * ( earx(i) + earx(i-1) )
+             ImW_conv(m,i) = ImW_conv(m,i) + depad_conv(i) * E**(1-Gamma)
+          end do
+
+       endif
+    end do
+
+  end subroutine conv_one_FFTw


### PR DESCRIPTION
# Refactor conv_one_FFT / conv_one_FFTw to derived types

## Checklist
- [x] I have HEASOFT installed and compiled
- [x] I compiled reltrans
- [x] I have run the test suite (pytest)

## Description

This PR addresses issue **#106**.

Both convolution helpers now take `config`/`model_args` instead of loose `DC`/`nlp` args, matching the `do_convolutions` and `init_cont` style:

```fortran
conv_one_FFT (config, model_args, dyn, earx, Gamma, photarx, reline, imline, ReW_conv, ImW_conv)
conv_one_FFTw(config, model_args, dyn, earx, Gamma, photarx, reline, imline, ReW_conv, ImW_conv)
```

Changes:
- **`conv_one_FFT`** — refactored in place; reads `config%DC` / `model_args%nlp` directly.
- **`conv_one_FFTw`** — **moved out of `module conv_mod`** into a new free subroutine `subroutines/utils/conv_one_FFTw.f90`, then refactored the same way. Registered in `header.h`.
- **`genreltrans.f90`** — dropped `conv_one_FFTw` from `use conv_mod`; updated all 8 call sites.

## Anything important?

- **Why `conv_one_FFTw` had to move:** it lived inside `conv_mod`, but `common_types` itself `use`s `conv_mod` — so a procedure inside `conv_mod` cannot `use common_types` (circular module dependency). Lifting it to a free subroutine (like `conv_one_FFT` / `init_cont`) is the clean fix.
- **`earx` and the `ReW`/`ImW` slices stay explicit:** they are per-iteration locals / per-`(W, frequency)` write-slices. Passing the whole `arrays` type alongside a written slice of it would be argument aliasing.
- **`dyn` left untouched** — its removal is issue #87.
