### PR TITLE
Add `IS_DEBUG_BUILD`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 ifeq ($(DEBUG),1)
 	# Compile reltrans in 'debug' mode, which means disabling optimisations and
 	# including debug symbols.
-	FFLAGS += -g
+	FFLAGS += -DRELTRANS_BUILD_DEBUG=1 -g
 	CFLAGS += -g
 else
 	# The default arguments used to compile reltrans

--- a/subroutines/constants.f90
+++ b/subroutines/constants.f90
@@ -1,5 +1,5 @@
-#ifndef _RELTRANS_IS_DEBUG
-#define _RELTRANS_IS_DEBUG 0
+#ifndef RELTRANS_BUILD_DEBUG
+#define RELTRANS_BUILD_DEBUG 0
 #endif
 
 module rtconstants
@@ -30,6 +30,11 @@ module rtconstants
         MODE_CROSS_SPEC_LAG_BOTH_FOLDED     =  6,                              &
         MODE_LAG_FREQ                       =  7,                              &
         MODE_CROSS_SPEC_LAG_TWO_RESPONSES   =  8
+
+    ! This parameter is passed in by the build system using the pre-processor.
+    ! It can be queried to see if the compiler is building for production or in
+    ! debug mode.
+    logical, parameter :: IS_DEBUG_BUILD = (RELTRANS_BUILD_DEBUG == 1)
 
 contains
 

--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -395,7 +395,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
     ! freed and re-allocated
 
     if (config%firstcall) then
-        call init_fftw_allconv()
+        call init_fftw_allconv(IS_DEBUG_BUILD)
         ! initialise environment and allocate all arrays
         call read_environment_variables(config)
         call setup_global_arrays(config, model_args%nlp)

--- a/subroutines/modules.f90
+++ b/subroutines/modules.f90
@@ -190,10 +190,11 @@ module conv_mod
 
 contains
   
-  subroutine init_fftw_allconv()
+  subroutine init_fftw_allconv(use_estimate)
     implicit none
     integer(c_int) :: flags, i
     integer, external :: omp_get_max_threads
+    logical, intent(in) :: use_estimate
     INTEGER FFTW_PATIENT
     PARAMETER (FFTW_PATIENT=32)
     !i = fftw_init_threads()
@@ -210,8 +211,12 @@ contains
     call c_f_pointer(a2, out_conv, [nex_conv])
     call c_f_pointer(a3, out     , [nec     ])
     call c_f_pointer(a4, in_conv , [nec     ])
-    !   flags = 0 + FFTW_ESTIMATE
-    flags = 0 + FFTW_PATIENT
+    if (use_estimate) then
+        ! Saves time on running the test suite.
+        flags = FFTW_ESTIMATE
+    else
+        flags = FFTW_PATIENT
+    endif
 
     ! note: these two are what kill the runtime of this subroutine
     plan1 = fftw_plan_dft_r2c_1d(nex_conv,  in, out, flags)


### PR DESCRIPTION
You likely all got email notifications about this, and I am sorry, but watching England vs Croatia was less interesting than quickly trying to finish this off after wine and disaronno. 

This can only be merged after #141 since it requires the new constants module.

Adds logic to only enable FFTW startup measurement when building in release, so that the tests are a bit quicker.