### PR TITLE
Coverage reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,8 @@ jobs:
           # Change directory to avoid any namespace / Python module clashes
           pytest -vvv test
       - name: Upload coverage to Codecov
+        # Only upload once, and on the ubuntu latest machine.
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: codecov/codecov-action@v5
         with:
           gcov: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,9 @@ jobs:
   # This is the actual unit test runner. It uses the Python pyreltrans wrapper
   # to run the tests, as that is the most lightweight and portable way to use
   # Reltrans.
-  test:
+  pip-test:
     runs-on: ${{ matrix.os }}
-    name: Test ${{ matrix.os }}
+    name: Python package ${{ matrix.os }}
     strategy:
       # Don't cancel in-progress if one fails.
       fail-fast: false
@@ -62,31 +62,14 @@ jobs:
         run: |
           python3 ./dist-package.py
           python3 -m pip install .
-      - name: Install GitHub CLI and fetch data files
+
+      - name: Check the import and DL open works
         run: |
-          sudo apt update && sudo apt install -y gh
+          python3 -c "import pyreltrans ; pyreltrans.Reltrans()"
 
-          # Authenticate with GitHub cli
-          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
-
-          # This release version will have to be changed if changes to the test
-          # data are made
-          gh release download v0.1.0 -D reltrans-data -R reltrans/model-data
-
-          # Stitch the large files back together
-          cd reltrans-data
-          cat $(ls xillverCp_v3.4_normalised.fits-* | sort -V) > xillverCp_v3.4_normalised.fits
-      - name: Smoketest pyreltrans
-        run: |
-          export RELTRANS_TABLES="$(realpath reltrans-data)"
-          # Change directory to avoid any namespace / Python module clashes
-          ( cd test ; pytest -vvv . )
-
-  # This test is to check that compiling using the Makefile gives something
-  # that works.
-  make-test:
+  test:
     runs-on: ${{ matrix.os }}
-    name: Makefile Build ${{ matrix.os }}
+    name: Test ${{ matrix.os }}
     strategy:
       # Don't cancel in-progress if one fails.
       fail-fast: false
@@ -105,8 +88,7 @@ jobs:
         uses: fortran-lang/setup-fortran@v1
       - name: Install xspectrampoline for HEASoft
         run: |
-          python3 -m pip install --upgrade xspectrampoline
-
+          python3 -m pip install --upgrade xspectrampoline pytest numpy
       # TODO: do something better here:
       # We also need the fftw.f03 file, since that is currently not shipped
       # with xspectrampoline
@@ -120,14 +102,34 @@ jobs:
         run: |
           sudo apt update && sudo apt install -y libfftw3-dev
           cp /usr/include/fftw3.f03 ./
-
-      - name: Compile reltrans and dummy target using the Makefile
+      - name: Build in debug with coverage
         run: |
-          # Setup the HEADAS environment variable
           export HEADAS="$(python3 -c 'import xspectrampoline_helpers as helpers ; print(helpers.get_HEADAS())')"
-          make DEBUG=1
-          # Build the dummy target and try to run it
-          make dummy DEBUG=1
-      - name: Run dummy target
+          make DEBUG=1 COVERAGE=1
+      - name: Install GitHub CLI and fetch data files
         run: |
-          ./build/bin/dummy
+          sudo apt update && sudo apt install -y gh
+
+          # Authenticate with GitHub cli
+          echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+          # This release version will have to be changed if changes to the test
+          # data are made
+          gh release download v0.1.0 -D reltrans-data -R reltrans/model-data
+
+          # Stitch the large files back together
+          cd reltrans-data
+          cat $(ls xillverCp_v3.4_normalised.fits-* | sort -V) > xillverCp_v3.4_normalised.fits
+      - name: Run tests with coverage
+        run: |
+          export RELTRANS_TABLES="$(realpath reltrans-data)"
+          # Change directory to avoid any namespace / Python module clashes
+          pytest -vvv test
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          gcov: true
+          gcov_include: wrappers.f90
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ DEBUG = 0
 # The `SANITIZE` option enables the address sanitizer in the library (see
 # below).
 SANITIZE = 0
+# The `COVERAGE` option compiles the library with coverage enabled. This can be
+# used with the `cov-report` target to generate a coverage breakdown.
+COVERAGE = 0
 
 # The name to use for the reltrans library (must be different from reltrans, as
 # libreltrans is the compiled reltrans library)
@@ -65,6 +68,12 @@ ifeq ($(SANITIZE),1)
 	CFLAGS += -fsanitize=address
 endif
 
+ifeq ($(COVERAGE),1)
+	# `-coverage` should be expanded to the other two but it isn't for all
+	# Fortran compiler versions.
+	FFLAGS += -coverage -fprofile-arcs -ftest-coverage
+endif
+
 ifeq ($(TARGET),Linux)
 	FFLAGS += -shared -export-dynamic
 	LDFLAGS += -lm -lpthread
@@ -100,6 +109,18 @@ exe: $(BUILD)/bin/relcli
 
 dummy: $(BUILD)/bin/dummy
 
+.PHONY: coverage
+coverage: coverage.info
+
+coverage.info:
+	# Requires both `gcov` and `lcov`
+	gcov -o $(BUILD)/cache -b wrappers.f90
+	lcov --gcov-tool gcov --capture --directory . --output-file coverage.info
+
+.PHONY: covreport
+covreport: coverage.info
+	genhtml --output-directory $(BUILD)/html coverage.info
+
 $(BUILD)/bin/relcli: ./utils/cli.c $(BUILD)/lib/libreltrans.$(SHARED_EXT)
 	$(CC) $(CFLAGS) utils/cli.c -o $@ \
 		-L$(BUILD)/lib -lgfortran -lc -lm $(EXE_LDFLAGS) \
@@ -131,6 +152,8 @@ $(BUILD):
 .PHONY: clean
 clean:
 	rm -rf $(BUILD)
+	rm -rf *.f90.gcov
+	rm -rf coverage.info
 
 .PHONY: format
 format:


### PR DESCRIPTION
Should henceforth generate code coverage reports on the tests.

This required a little bit more work than it should have because the tests were previously run off of the pip package instead of the Makefile. I've logged that in the commit message so it's clear why that was changed in the history.

Behind the scenes, I added a new secret to the repository (`CODECOV_TOKEN`) so that the upload to Codecov would work automatically. 