### PR TITLE
bug fix: internal frequency grid was not recalculated if nf didn't change but flo/fhi did

### DIFF
--- a/subroutines/checks.f90
+++ b/subroutines/checks.f90
@@ -31,55 +31,53 @@ subroutine need_check(Cp,Cpsave,param,paramsave,fhi,flo,fhisave,flosave,nf,nfsav
   ! OUTPUTS
   !   needtrans: if true, we must do the kernel calculation
   !   neecconv:  if true, we must do the convolution
-  implicit none 
-  integer         , intent(in)  :: Cp, Cpsave, nf, nfsave
-  real            , intent(in)  :: param(32), paramsave(32)
-  real            , parameter   :: tol = 1e-7
-  double precision, intent(in)  :: fhi, flo, fhisave, flosave
-  double precision, parameter   :: dtol = 1e-10
-  logical         , intent(out) :: needtrans,needconv
-  integer :: i
+    implicit none 
+    integer         , intent(in)  :: Cp, Cpsave, nf, nfsave
+    real            , intent(in)  :: param(32), paramsave(32)
+    real            , parameter   :: tol = 1e-7
+    double precision, intent(in)  :: fhi, flo, fhisave, flosave
+    double precision, parameter   :: dtol = 1e-5
+    logical         , intent(out) :: needtrans,needconv
+    integer :: i
 
-  ! functions
-  integer :: get_env_int
-  needtrans = .false.
-  needconv  = .false.
+    ! functions
+    integer :: get_env_int
+    needtrans = .false.
+    needconv  = .false.
 
-  ! Optionally disable the caches
-  if (0 .ne. get_env_int("REV_NOSAV", 0)) then
-      print *, "Applying cache overwrite"
-      needtrans = .true.
-      needconv = .true.
-      return
-  end if
+    ! Optionally disable the caches
+    if (0 .ne. get_env_int("REV_NOSAV", 0)) then
+        print *, "Applying cache overwrite"
+        needtrans = .true.
+        needconv = .true.
+        return
+    end if
 
-! First check the parameter entries
-  do i = 1,9
-     if( abs( param(i) - paramsave(i) ) .gt. tol ) needtrans = .true.
-  end do
-  i = 11
-  if( abs( param(i) - paramsave(i) ) .gt. tol ) needtrans = .true.
-  i = 13
-  if( abs( param(i) - paramsave(i) ) .gt. tol ) needtrans = .true.
-  !i = 18
-  !if( abs( param(i) - paramsave(i) ) .gt. tol ) needtrans = .true. !note: i=19 is the mass
-  do i = 18,22
-     if( abs( param(i) - paramsave(i) ) .gt. tol ) needtrans = .true.
-  end do
-  i = 31
-  if( abs( param(i) - paramsave(i) ) .gt. tol ) needtrans = .true.
-! Now check if frequency range and frequency grid have changed 
-  if( nf .ne. nfsave ) then
-     needtrans = .true.
-  else if( abs( fhi - fhisave ) .gt. dtol) then
-     needtrans = .true.
-  else if( abs( flo - flosave ) .gt. dtol) then
-     needtrans = .true.
-  end if
-!Now for needconv
-  if( needtrans ) needconv = .true.
-  if( Cp .ne. Cpsave ) needconv = .true.
-  if( abs( param(10) - paramsave(10) ) .gt. tol ) needconv = .true.
-  if( abs( param(12) - paramsave(12) ) .gt. tol ) needconv = .true.
+    ! First check the parameter entries
+    do i = 1,9
+        if( abs( param(i) - paramsave(i) ) .gt. tol ) needtrans = .true.
+    end do
+    i = 11
+    if( abs( param(i) - paramsave(i) ) .gt. tol ) needtrans = .true.
+    i = 13
+    if( abs( param(i) - paramsave(i) ) .gt. tol ) needtrans = .true.
+    do i = 18,22
+        if( abs( param(i) - paramsave(i) ) .gt. tol ) needtrans = .true.
+    end do
+    i = 31
+    if( abs( param(i) - paramsave(i) ) .gt. tol ) needtrans = .true.
+    ! Now check if frequency range and frequency grid have changed 
+    if( nf .ne. nfsave ) then
+        needtrans = .true.
+    else if( abs(1.- (fhi / fhisave) ) .gt. dtol) then
+        needtrans = .true.
+    else if( abs(1. - (flo - flosave) ) .gt. dtol) then
+        needtrans = .true.
+    end if
+    !Now for needconv
+    if( needtrans ) needconv = .true.
+    if( Cp .ne. Cpsave ) needconv = .true.
+    if( abs( param(10) - paramsave(10) ) .gt. tol ) needconv = .true.
+    if( abs( param(12) - paramsave(12) ) .gt. tol ) needconv = .true.
 end subroutine need_check
 !-----------------------------------------------------------------------

--- a/subroutines/checks.f90
+++ b/subroutines/checks.f90
@@ -80,4 +80,3 @@ subroutine need_check(Cp,Cpsave,param,paramsave,fhi,flo,fhisave,flosave,nf,nfsav
     if( abs( param(10) - paramsave(10) ) .gt. tol ) needconv = .true.
     if( abs( param(12) - paramsave(12) ) .gt. tol ) needconv = .true.
 end subroutine need_check
-!-----------------------------------------------------------------------

--- a/subroutines/checks.f90
+++ b/subroutines/checks.f90
@@ -30,7 +30,33 @@ subroutine need_check(Cp,Cpsave,param,paramsave,fhi,flo,fhisave,flosave,nf,nfsav
   !   nfsave:    saved number
   ! OUTPUTS
   !   needtrans: if true, we must do the kernel calculation
-  !   neecconv:  if true, we must do the convolution
+!> Checks if reltrans needs to calculate the kernel
+!> Parameters that rtrans() is sensitive to:
+!> (1-9):   h1,h2,a,inc,rin,rout,zcos,Gamma,logxi/Dkpc
+!> (11):    lognep
+!> (13):    eta_0
+!> (18):    qboost
+!> (20-22): honr,b1,b2
+!> (31):    Anorm
+!> Also need to check if the frequency range changes
+!>
+!> Parameters the restframe spec is sensitive to
+!> (10):     Afe
+!> (12):    Ecut/kTe  
+!> Inputs:
+!>     Cp:        defines which model
+!>     Cpsave:    saved Cp
+!>     param:     parameter array
+!>     paramsave: saved array
+!>     fhi:       high frequency range
+!>     flo:       low frequency range
+!>     fhisave:   saved frequency 
+!>     flosave:   saved frequency 
+!>     nf:        number of frequency bins
+!>     nfsave:    saved number
+!> Outputs:
+!>     needtrans: if true, we must do the kernel calculation
+!>     neecconv:  if true, we must do the convolution
     implicit none 
     integer         , intent(in)  :: Cp, Cpsave, nf, nfsave
     real            , intent(in)  :: param(32), paramsave(32)

--- a/subroutines/common.f90
+++ b/subroutines/common.f90
@@ -323,12 +323,15 @@ contains
         integer :: i
         logical :: needs_allocating
         double precision :: fhisave, flosave
-        double precision, parameter   :: dtol = 1e-10
+        double precision :: fhicheck, flocheck 
+        double precision, parameter   :: dtol = 1e-5
 
-! abs( fhi - fhisave ) .gt. dtol
-        if ( abs(model_args%floHz - flosave) .gt. dtol ) then
+        fhicheck = fhisave /(4.92695275718945d-06 * model_args%Mass)
+        flocheck = flosave /(4.92695275718945d-06 * model_args%Mass)            
+
+        if ( abs(1. - model_args%floHz/flocheck) .gt. dtol ) then
             needs_allocating = .true.
-        else if ( abs(model_args%fhiHz - fhisave) .gt. dtol ) then
+        else if ( abs(1. - model_args%fhiHz/fhicheck) .gt. dtol ) then
             needs_allocating = .true.
         else if (allocated(arrays%fix)) then
             needs_allocating = prev_nf .ne. config%nf

--- a/subroutines/common.f90
+++ b/subroutines/common.f90
@@ -323,10 +323,12 @@ contains
         integer :: i
         logical :: needs_allocating
         double precision :: fhisave, flosave
+        double precision, parameter   :: dtol = 1e-10
 
-        if (flosave .ne. model_args%floHz) then
+! abs( fhi - fhisave ) .gt. dtol
+        if ( abs(model_args%floHz - flosave) .gt. dtol ) then
             needs_allocating = .true.
-        else if (fhisave .ne. model_args%fhiHz) then
+        else if ( abs(model_args%fhiHz - fhisave) .gt. dtol ) then
             needs_allocating = .true.
         else if (allocated(arrays%fix)) then
             needs_allocating = prev_nf .ne. config%nf

--- a/subroutines/common.f90
+++ b/subroutines/common.f90
@@ -314,7 +314,7 @@ contains
     end subroutine setup_arrays
 
     ! Reallocate arrays depending on whether they need to be resized
-    subroutine realloc_arrays(config, model_args, arrays, prev_nf)
+    subroutine realloc_arrays(config, model_args, arrays, prev_nf, flosave, fhisave)
         use conv_mod, only: nex
         type(t_config), intent(in) :: config
         type(t_model_arguments), intent(in) :: model_args
@@ -322,8 +322,13 @@ contains
         integer, intent(in) :: prev_nf
         integer :: i
         logical :: needs_allocating
+        double precision :: fhisave, flosave
 
-        if (allocated(arrays%fix)) then
+        if (flosave .ne. model_args%floHz) then
+            needs_allocating = .true.
+        else if (fhisave .ne. model_args%fhiHz) then
+            needs_allocating = .true.
+        else if (allocated(arrays%fix)) then
             needs_allocating = prev_nf .ne. config%nf
         else
             needs_allocating = .true.
@@ -339,7 +344,7 @@ contains
                     *(model_args%fhiHz                                         &
                     / model_args%floHz)**(real(i) / real(config%nf))
             end do
-            
+                       
             ! reallocate the transfer function arrays
             if (allocated(arrays%ker_W0)) deallocate(arrays%ker_W0)
             allocate(arrays%ker_W0(model_args%nlp,nex,config%nf,config%me,config%xe))

--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -415,8 +415,8 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
     end if
 
     ! reallocated frequency dependent arrays
-    call realloc_arrays(config, model_args, arrays, prev_nf)
-
+    call realloc_arrays(config, model_args, arrays, prev_nf, flosave, fhisave)
+    
     ifl = 1
 
     ! Note: the two different calls are because for the double lP we set the


### PR DESCRIPTION
## Checklist
- [x] I have HEASOFT installed and compiled 
- [x] I compiled reltrans
- [x] I have run the test suite (pytest)

## Description of this PR
`realloc_arrays` was checking whether the number of frequency bins had changed, but not whether the bounds had changed, and so sometimes it was skipping recalculating the internal frequency grid. This should now be fixed. 

## Anything important?
Tests are still pending, we need to include a subroutine in the interface which allows us to retrive the internal frequency grid
