### PR TITLE
Test suite plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ run_model.py
 **.egg-info
 **.pdf
 .gdbinit
+test/_plots

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ __pycache__
 __pycache__/*
 lib_reltrans.so*
 run_model.py
+**.swp
+**.orig
+**.egg-info
+**.pdf
+.gdbinit

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,12 +4,17 @@ import inspect
 import pathlib
 import logging
 import dataclasses
+import enum
 
 from typing import Any
+
+DEFAULT_TOLERANCE_ABS = 0
+DEFAULT_TOLERANCE_REL = 2e-4
 
 # The `test` directory
 ROOT_DIR = pathlib.Path(pathlib.Path(__file__).parent)
 SNAPSHOT_DIR = ROOT_DIR / "_snapshots"
+PLOT_DIR = ROOT_DIR / "_plots"
 
 import pytest
 
@@ -22,6 +27,110 @@ except ModuleNotFoundError:
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+
+def _get_calling_function_name(name: str | None) -> str:
+    """
+    Get the calling function's name. A name may be provided that will be
+    appended as a tail.
+    """
+    caller_name = inspect.currentframe().f_back.f_back.f_code.co_name
+    if name:
+        return f"{caller_name}.{name}"
+    return caller_name
+
+
+class PlotMode(enum.Enum):
+    ALWAYS_PLOT = 1
+    PLOT_ON_FAIL = 2
+    NO_PLOT = 0
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--plot",
+        action="store",
+        help="Whether to save debugging plots when tests fail.",
+        default=True,
+    )
+    parser.addoption(
+        "--plot-always",
+        action="store",
+        help="Whether to save debugging plots irrespective of whether tests fail.",
+        default=False,
+    )
+
+
+@pytest.fixture
+def plotting_mode(request):
+    """
+    This fixture can be used to get boolean that tells the test or fixture
+    whether to enable debug plotting on fail.
+    """
+    if request.config.getoption("--plot-always"):
+        return PlotMode.ALWAYS_PLOT
+    if request.config.getoption("--plot"):
+        return PlotMode.PLOT_ON_FAIL
+    return PlotMode.NO_PLOT
+
+
+def _plot_with_ratio(
+    x: np.ndarray, y1: np.ndarray, y2: np.ndarray, title: str, **kwargs
+):
+    import matplotlib.pyplot as plt
+
+    fig, axes = plt.subplots(nrows=2, figsize=(10, 6))
+
+    residuals = (y1 - y2) / y2
+    axes[1].plot(x, residuals)
+
+    units = kwargs.get("units", "f")
+    if len(units) > 1:
+        units_unknown = False
+
+        y1_tmp = y1.copy()
+        y2_tmp = y2.copy()
+
+        for c in units[:-1]:
+            if c == "e":
+                y1_tmp *= x
+                y2_tmp *= x
+            else:
+                units_unknown = True
+                break
+
+        if units[-1] != "f":
+            units_unknown = True
+
+        if units_unknown:
+            logger.warn(f"Unknown plotting units '{units}'. Plotting as is.")
+            y1_tmp = y1
+            y2_tmp = y2
+
+        y1 = y1_tmp
+        y2 = y2_tmp
+
+    axes[0].plot(x, y1, label=kwargs.get("label1", "actual"))
+    axes[0].plot(x, y2, label=kwargs.get("label2", "expected"))
+
+    axes[0].set_title(title)
+    axes[0].legend()
+
+    # The y-scale is separated for the two axes:
+    axes[0].set_yscale(kwargs.get("yscale", "linear"))
+    axes[1].set_yscale(kwargs.get("yscale_ratio", "linear"))
+    axes[0].set_ylabel(kwargs.get("ylabel", "y") + f" (units: {units})")
+    axes[1].set_ylabel("(y1 - y2) / y2")
+
+    print(kwargs)
+
+    for ax in axes:
+        ax.set_xlabel(kwargs.get("xlabel", "x"))
+        ax.set_xscale(kwargs.get("xscale", "linear"))
+
+    fig.tight_layout()
+
+    return fig
 
 
 def _get_snapshot(name: str) -> None | np.ndarray:
@@ -109,7 +218,44 @@ def reltrans() -> pyreltrans.Reltrans:
 
 
 @pytest.fixture
-def assert_snapshot() -> callable:
+def save_plot(plotting_mode) -> callable:
+    """
+    This fixture can be used to save debugging plots depending on the `--plot`
+    command line argument.
+    """
+
+    def plot_function(
+        domain: np.ndarray | None,
+        data: np.ndarray,
+        snapshot: np.ndarray,
+        name: str | None = None,
+        derive_name_from_callstack=True,
+        plotter_function: callable = _plot_with_ratio,
+        atol=DEFAULT_TOLERANCE_ABS,
+        rtol=DEFAULT_TOLERANCE_REL,
+        **kwargs,
+    ):
+
+        if derive_name_from_callstack:
+            name = _get_calling_function_name(name)
+        else:
+            name = name or "[name missing]"
+
+        if (plotting_mode == PlotMode.ALWAYS_PLOT) or (
+            (plotting_mode == PlotMode.PLOT_ON_FAIL)
+            and not np.allclose(data, snapshot, rtol=rtol, atol=atol)
+        ):
+            domain = domain if domain is not None else np.array(range(len(data)))
+            fig = plotter_function(domain, data, snapshot, name, **kwargs)
+            # Then save the plot after ensuring the plot directory exists:
+            PLOT_DIR.mkdir(parents=True, exist_ok=True)
+            fig.savefig(PLOT_DIR / (name + ".jpg"))
+
+    return plot_function
+
+
+@pytest.fixture
+def assert_snapshot(save_plot) -> callable:
     """
     Fixture used to assert that snapshots are reproduced to within specified
     tolerances.
@@ -127,15 +273,19 @@ def assert_snapshot() -> callable:
     turns out the order of operations incrues different rounding errors, which,
     as reltrans functions over a very large numerical range (that is, very many
     orders of magnitude), build up to the ~0.1% percent level.
+
+    All other keyword arguments are passed to the debug plotting function.
     """
 
-    def _assert_snapshot_equal(data: np.ndarray, name="", rtol=2e-4, atol=0) -> bool:
-        calling_context = inspect.stack()[1][3]
-
-        snapshot_name = calling_context
-        if name:
-            snapshot_name = f"{snapshot_name}.{name}"
-
+    def _assert_snapshot_equal(
+        data: np.ndarray,
+        name="",
+        rtol=DEFAULT_TOLERANCE_REL,
+        atol=DEFAULT_TOLERANCE_ABS,
+        domain: np.ndarray | None = None,
+        **kwargs,
+    ) -> bool:
+        snapshot_name = _get_calling_function_name(name)
         snapshot = _get_snapshot(snapshot_name)
         if snapshot is None:
             # TODO: print warning that no snapshot exists and that a new one
@@ -147,6 +297,14 @@ def assert_snapshot() -> callable:
             _create_snapshot(snapshot_name, data)
             return True
 
+        save_plot(
+            domain,
+            data,
+            snapshot,
+            name=snapshot_name,
+            derive_name_from_callstack=False,
+            **kwargs,
+        )
         np.testing.assert_allclose(data, snapshot, rtol=rtol, atol=atol)
 
     return _assert_snapshot_equal

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -235,6 +235,11 @@ def save_plot(plotting_mode) -> callable:
         rtol=DEFAULT_TOLERANCE_REL,
         **kwargs,
     ):
+        try:
+            import matplotlib.pyplot as plt
+        except ImportError:
+            logger.warn("matplotlib missing, cannot create debug plot.")
+            return
 
         if derive_name_from_callstack:
             name = _get_calling_function_name(name)

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -2,57 +2,27 @@ import pytest
 import numpy as np
 from pyreltrans import DCP_Parameters, Dbl_Parameters, rtdist_Parameters
 
+from conftest import _get_snapshot
 
-def _debug_plot(
-        energy, output, title="", xlabel="", ylabel="", yscale="linear", xscale="log", ylim_min=None, ylim_max=None):
-    """Used when creating new tests for quickly looking at the data to make
-    sure it is sensible."""
-    import matplotlib.pyplot as plt
-
-    plt.clf()
-    plt.plot(energy[0:-1], output)
-    plt.xscale(xscale)
-    plt.yscale(yscale)
-    plt.xlabel(xlabel)
-    plt.ylabel(ylabel)
-    plt.title(title)
-    if ylim_min is not None and ylim_max is not None:
-        plt.ylim(ylim_min, ylim_max)
-    plt.show()
+plot_spectral_kwargs = dict(
+        yscale = "log", xlabel = "Energy", ylabel = "Flux" , xscale = "log", units = "ef"
+)
 
 
-def _debug_plot_multi_spec(energy, output, title="", xlabel="", ylabel="", yscale="linear", xscale="log"):
-    """Used when creating new tests for quickly looking at the data to make
-    sure it is sensible."""
-    import matplotlib.pyplot as plt
-
-    plt.clf()
-    for spec in output:
-        plt.plot(energy[0:-1], spec)
-    plt.xscale(xscale)
-    plt.yscale(yscale)
-    plt.xlabel(xlabel)
-    plt.ylabel(ylabel)
-    plt.title(title)
-    plt.show()
-
-
+@pytest.mark.rt
 def test_basic_invocation(reltrans, assert_snapshot):
     """A smoke test to check whether the default values are working."""
     reltrans.reset()
     energy = np.logspace(np.log10(0.1), np.log10(100), 501)
     output = reltrans.dcp(energy, DCP_Parameters())
-    # _debug_plot(energy,output, "reltransDCp time-averaged spectrum [default parameters]")
-    assert_snapshot(output)
-
+    assert_snapshot(output, domain = energy[0:-1], **plot_spectral_kwargs)
 
 def test_basic_absorption_invocation(reltrans, assert_snapshot):
     """A smoke test to check whether absorption is being correctly applied."""
     reltrans.reset()
     energy = np.logspace(np.log10(0.1), np.log10(100), 501)
     output = reltrans.dcp(energy, DCP_Parameters(nh = 0.2))
-    # _debug_plot(energy,output, "reltransDCp time-averaged spectrum [default parameters]")
-    assert_snapshot(output)
+    assert_snapshot(output, domain = energy[0:-1], **plot_spectral_kwargs)
 
 
 def test_dcp_continuum(reltrans, assert_snapshot):
@@ -60,10 +30,7 @@ def test_dcp_continuum(reltrans, assert_snapshot):
     reltrans.reset()
     energy = np.logspace(np.log10(0.1), np.log10(100), 501)
     output = reltrans.dcp(energy, DCP_Parameters(boost = 0))
-    # E = (energy[1:] + energy[:-1]) * 0.5
-    # dE = (energy[1:] - energy[:-1])
-    # _debug_plot(energy, output/dE*E**2, "reltransDCp time-averaged spectrum [boost = 0]", yscale="log", xscale="log")
-    assert_snapshot(output)
+    assert_snapshot(output, domain = energy[0:-1], **plot_spectral_kwargs)
 
 
 def test_dcp_reflection(reltrans, assert_snapshot):
@@ -71,13 +38,10 @@ def test_dcp_reflection(reltrans, assert_snapshot):
     reltrans.reset()
     energy = np.logspace(np.log10(0.1), np.log10(100), 501)
     output = reltrans.dcp(energy, DCP_Parameters(boost = -1))
-    # E = (energy[1:] + energy[:-1]) * 0.5
-    # dE = (energy[1:] - energy[:-1])
-    # _debug_plot(energy,output/dE*E**2, "reltransDCp time-averaged spectrum [boost = -1]", yscale="log", xscale="log")
-    assert_snapshot(output)
+    assert_snapshot(output, domain = energy[0:-1], **plot_spectral_kwargs)
 
 
-def test_dcp_to_dbl_continuum(reltrans, assert_snapshot):
+def test_dcp_to_dbl_continuum(reltrans, assert_snapshot, save_plot):
     """Test to compare the continuum output of reltransDCp and reltransDBL (boost = 0)"""
     reltrans.reset()
     energy = np.logspace(np.log10(0.1), np.log10(100), 501)
@@ -85,16 +49,19 @@ def test_dcp_to_dbl_continuum(reltrans, assert_snapshot):
     output_dcp = reltrans.dcp(energy, xrb)
     reltrans.reset()
     output_dbl = reltrans.dbl_lamp(energy, Dbl_Parameters(h1 = xrb.h, h2 = xrb.h, a = xrb.a, boost = 0))
-    # ratio = output_dbl/output_dcp
-    # outputs = np.stack((output_dcp, output_dbl))
-    # E = (energy[1:] + energy[:-1]) * 0.5
-    # dE = (energy[1:] - energy[:-1])
-    # _debug_plot_multi_spec(energy, outputs, "reltrans time-averaged spectrum [boost = 0]", yscale="log", xscale="log")
-    # _debug_plot(energy, ratio, "ratio dcp to dbl [boost = -1]", yscale="log", xscale="log")
+    save_plot(
+        energy[0:-1],
+        output_dcp,
+        output_dbl,
+        label1="DCP",
+        label2="DBL",
+        rtol = 1e-4,
+        **plot_spectral_kwargs,
+    )
     np.testing.assert_allclose(output_dcp, output_dbl, rtol=1e-4)
 
 
-def test_dcp_to_dbl_reflection_only(reltrans, assert_snapshot):
+def test_dcp_to_dbl_reflection_only(reltrans, assert_snapshot, save_plot):
     """Test to check if the reflection-only outputs (boost = -1)
     of reltransDCp and reltransDBL are the same if the heights
     of the two lampposts are the same"""
@@ -104,16 +71,19 @@ def test_dcp_to_dbl_reflection_only(reltrans, assert_snapshot):
     output_dcp = reltrans.dcp(energy, xrb)
     reltrans.reset()
     output_dbl = reltrans.dbl_lamp(energy, Dbl_Parameters(h1 = xrb.h, h2 = xrb.h, a = xrb.a, boost = xrb.boost))
-    # ratio = output_dbl/output_dcp
-    # outputs = np.stack((output_dcp, output_dbl))
-    # E = (energy[1:] + energy[:-1]) * 0.5
-    # dE = (energy[1:] - energy[:-1])
-    # _debug_plot_multi_spec(energy, outputs, "reltrans time-averaged spectrum [boost = -1]", yscale="log", xscale="log")
-    # _debug_plot(energy, ratio, "ratio dcp to dbl [boost = 0]", yscale="log", xscale="log")
+    save_plot(
+        energy[0:-1],
+        output_dcp,
+        output_dbl,
+        label1="DCP",
+        label2="DBL",
+        rtol = 1e-4,
+        **plot_spectral_kwargs,
+    )
     np.testing.assert_allclose(output_dcp, output_dbl, rtol=1e-4)
 
 
-def test_dcp_to_dbl_eta0_reflection_only(reltrans, assert_snapshot):
+def test_dcp_to_dbl_eta0_reflection_only(reltrans, assert_snapshot, save_plot):
     """Test to check if the reflection-only outputs (boost = -1)
     of reltransDCp and reltransDBL are the same if the heights
     of the two lampposts are different, BUT eta_0 == 0 (which means that
@@ -124,16 +94,19 @@ def test_dcp_to_dbl_eta0_reflection_only(reltrans, assert_snapshot):
     output_dcp = reltrans.dcp(energy, xrb)
     reltrans.reset()
     output_dbl = reltrans.dbl_lamp(energy, Dbl_Parameters(h1 = xrb.h, h2 = 100.0, a = xrb.a, boost = xrb.boost, eta_0 = 0.0))
-    # ratio = output_dbl/output_dcp
-    # outputs = np.stack((output_dcp, output_dbl))
-    # E = (energy[1:] + energy[:-1]) * 0.5
-    # dE = (energy[1:] - energy[:-1])
-    # _debug_plot_multi_spec(energy, outputs, "reltrans time-averaged spectrum [boost = -1]", yscale="log", xscale="log")
-    # _debug_plot(energy, ratio, "ratio dcp to dbl [boost = 0]", yscale="log", xscale="log")
+    save_plot(
+        energy[0:-1],
+        output_dcp,
+        output_dbl,
+        label1="DCP",
+        label2="DBL",
+        rtol = 1e-4,
+        **plot_spectral_kwargs,
+    )
     np.testing.assert_allclose(output_dcp, output_dbl, rtol=1e-4)
 
 
-def test_dcp_to_dbl_full_spectrum(reltrans, assert_snapshot):
+def test_dcp_to_dbl_full_spectrum(reltrans, assert_snapshot, save_plot):
     """Test to check if the full time-averaged spectra (boost = 1)
     of reltransDCp and reltransDBL are the same if the heights
     of the two lampposts are the same"""
@@ -143,16 +116,19 @@ def test_dcp_to_dbl_full_spectrum(reltrans, assert_snapshot):
     output_dcp = reltrans.dcp(energy, xrb)
     reltrans.reset()
     output_dbl = reltrans.dbl_lamp(energy, Dbl_Parameters(h1 = xrb.h, h2 = xrb.h, a = xrb.a, boost = xrb.boost))
-    # ratio = output_dbl/output_dcp
-    # outputs = np.stack((output_dcp, output_dbl))
-    # E = (energy[1:] + energy[:-1]) * 0.5
-    # dE = (energy[1:] - energy[:-1])
-    # _debug_plot_multi_spec(energy, outputs, "reltrans time-averaged spectrum [boost = 1]", yscale="log", xscale="log")
-    # _debug_plot(energy, ratio, "ratio dcp to dbl [boost = 1]", yscale="log", xscale="log")
+    save_plot(
+        energy[0:-1],
+        output_dcp,
+        output_dbl,
+        label1="DCP",
+        label2="DBL",
+        rtol = 1e-4,
+        **plot_spectral_kwargs,
+    )
     np.testing.assert_allclose(output_dcp, output_dbl, rtol=1e-4)
 
 
-def test_dcp_to_dbl_eta0_full_spectrum(reltrans, assert_snapshot):
+def test_dcp_to_dbl_eta0_full_spectrum(reltrans, assert_snapshot, save_plot):
     """Test to check if the full time-averaged spectra (boost = 1)
     of reltransDCp and reltransDBL are the same if the heights
     of the two lampposts are different, BUT eta_0 == 0 (which means that
@@ -163,12 +139,15 @@ def test_dcp_to_dbl_eta0_full_spectrum(reltrans, assert_snapshot):
     output_dcp = reltrans.dcp(energy, xrb)
     reltrans.reset()
     output_dbl = reltrans.dbl_lamp(energy, Dbl_Parameters(h1 = xrb.h, h2 = xrb.h, a = xrb.a, boost = xrb.boost, eta_0 = 0))
-    # ratio = output_dbl/output_dcp
-    # outputs = np.stack((output_dcp, output_dbl))
-    # E = (energy[1:] + energy[:-1]) * 0.5
-    # dE = (energy[1:] - energy[:-1])
-    # _debug_plot_multi_spec(energy, outputs, "reltrans time-averaged spectrum [boost = 1]", yscale="log", xscale="log")
-    # _debug_plot(energy, ratio, "ratio dcp to dbl [boost = 1]", yscale="log", xscale="log")
+    save_plot(
+        energy[0:-1],
+        output_dcp,
+        output_dbl,
+        label1="DCP",
+        label2="DBL",
+        rtol = 1e-4,
+        **plot_spectral_kwargs,
+    )
     np.testing.assert_allclose(output_dcp, output_dbl, rtol=1e-4)
 
 
@@ -186,19 +165,46 @@ def test_re_im_parameter(reltrans, assert_snapshot, telescope, envars):
 
     xrb1 = DCP_Parameters(mass=10.0, flo_hz=0.122, fhi_hz=0.224, re_im=4.0)
     output = reltrans.dcp(energy, xrb1)
-    assert_snapshot(output, name="time_lag", atol=1e-9)
+
+    assert_snapshot(
+        output,
+        name="time_lag",
+        atol=1e-9,
+        xscale = "log",
+        xlabel = "Energy",
+        domain = energy[0:-1]
+    )
 
     xrb1.re_im = 1
     output = reltrans.dcp(energy, xrb1)
-    assert_snapshot(output, name="real_part")
-
+    assert_snapshot(
+        output,
+        name="real_part",
+        xscale = "log",
+        xlabel = "Energy",
+        domain = energy[0:-1]
+    )
     xrb1.re_im = 2
     output = reltrans.dcp(energy, xrb1)
-    assert_snapshot(output, name="imaginary_part", rtol=1e-3)
+    assert_snapshot(
+        output,
+        name="imaginary_part",
+        rtol=1e-3,
+        xscale = "log",
+        xlabel = "Energy",
+        domain = energy[0:-1]
+    )
 
     xrb1.re_im = 3
     output = reltrans.dcp(energy, xrb1)
-    assert_snapshot(output, name="magnitude")
+    assert_snapshot(
+        output,
+        name="magnitude",
+        rtol=1e-3,
+        xscale = "log",
+        xlabel = "Energy",
+        domain = energy[0:-1]
+    )
 
 
 def test_re_im_5_6(reltrans, assert_snapshot, telescope, envars):
@@ -216,13 +222,11 @@ def test_re_im_5_6(reltrans, assert_snapshot, telescope, envars):
 
     xrb1 = DCP_Parameters(mass=10.0, flo_hz=0.122, fhi_hz=0.224, re_im=6.0)
     output = reltrans.dcp(energy, xrb1)/dE
-    # _debug_plot(energy,output, title = "reltrans lag spectrum", xlabel="Energy [keV]", ylim_min=-1e-3, ylim_max=1e-3)
-    assert_snapshot(output, name="time_lag")
+    assert_snapshot(output, name="time_lag", xlabel = "Energy", ylabel = "Lag / dE", domain = energy[0:-1])
 
     xrb1.re_im = 5
     output = reltrans.dcp(energy, xrb1)
-    # _debug_plot(energy,output, title = "reltrans modulus spectrum", xlabel="Energy [keV]")
-    assert_snapshot(output, name="real_part")
+    assert_snapshot(output, name="real_part", xlabel = "Energy", domain = energy[0:-1])
 
 
 def test_ReIm8_check_second_response(reltrans,  assert_snapshot, telescope, envars):
@@ -252,8 +256,7 @@ def test_basic_invocation_reltransDbl(reltrans, assert_snapshot, envars):
     reltrans.reset()
     energy = np.logspace(np.log10(0.1), np.log10(100), 501)
     output = reltrans.dbl_lamp(energy, Dbl_Parameters())
-    # _debug_plot(energy,output, "rtdist time-averaged spectrum [default parameters]", xlabel="Energy [keV]", xscale='log', yscale='log')
-    assert_snapshot(output)
+    assert_snapshot(output, domain = energy[0:-1], **plot_spectral_kwargs)
 
 
 def test_re_im_reltransDbl(reltrans, assert_snapshot, telescope, envars):
@@ -297,7 +300,7 @@ def test_basic_invocation_rtdist(reltrans, assert_snapshot, envars):
     energy = np.logspace(np.log10(0.1), np.log10(100), 501)
     output = reltrans.rtdist(energy, rtdist_Parameters())
     # _debug_plot(energy,output, "rtdist time-averaged spectrum [default parameters]")
-    assert_snapshot(output)
+    assert_snapshot(output, domain = energy[0:-1], **plot_spectral_kwargs)
 
 
 def test_basic_invocation_rtdist_adens0(reltrans, assert_snapshot, envars):
@@ -308,7 +311,7 @@ def test_basic_invocation_rtdist_adens0(reltrans, assert_snapshot, envars):
     energy = np.logspace(np.log10(0.1), np.log10(100), 501)
     output = reltrans.rtdist(energy, rtdist_Parameters())
     # _debug_plot(energy,output, "rtdist time-averaged spectrum [default parameters]")
-    assert_snapshot(output)
+    assert_snapshot(output, domain = energy[0:-1], **plot_spectral_kwargs)
 
 
 def test_re_im_rtdist(reltrans, assert_snapshot, telescope, envars):

--- a/test/test_basics.py
+++ b/test/test_basics.py
@@ -20,7 +20,7 @@ def _debug_plot(
         plt.ylim(ylim_min, ylim_max)
     plt.show()
 
-    
+
 def _debug_plot_multi_spec(energy, output, title="", xlabel="", ylabel="", yscale="linear", xscale="log"):
     """Used when creating new tests for quickly looking at the data to make
     sure it is sensible."""
@@ -35,8 +35,8 @@ def _debug_plot_multi_spec(energy, output, title="", xlabel="", ylabel="", yscal
     plt.ylabel(ylabel)
     plt.title(title)
     plt.show()
-    
-    
+
+
 def test_basic_invocation(reltrans, assert_snapshot):
     """A smoke test to check whether the default values are working."""
     reltrans.reset()
@@ -170,7 +170,7 @@ def test_dcp_to_dbl_eta0_full_spectrum(reltrans, assert_snapshot):
     # _debug_plot_multi_spec(energy, outputs, "reltrans time-averaged spectrum [boost = 1]", yscale="log", xscale="log")
     # _debug_plot(energy, ratio, "ratio dcp to dbl [boost = 1]", yscale="log", xscale="log")
     np.testing.assert_allclose(output_dcp, output_dbl, rtol=1e-4)
-    
+
 
 def test_re_im_parameter(reltrans, assert_snapshot, telescope, envars):
     """Test the re_im parameter to assert that all the different outputs of the
@@ -240,7 +240,7 @@ def test_ReIm8_check_second_response(reltrans,  assert_snapshot, telescope, enva
     output = reltrans.dcp(energy, xrb1)
     resp2_needed = reltrans.get_needresp2()
     assert resp2_needed
-    
+
     xrb1 = DCP_Parameters(mass=10.0, flo_hz=1, fhi_hz=2, re_im=8.0)
     output = reltrans.dcp(energy, xrb1)
     resp2_needed = reltrans.get_needresp2()
@@ -384,7 +384,7 @@ def test_rtdist_called_twice_lag_and_time_averaged(reltrans, telescope, envars):
     output_rtdist2 = reltrans.rtdist(energy, rtdist_Parameters())
     np.testing.assert_allclose(output_rtdist_lag, output_rtdist_lag2, rtol=1e-4)
     np.testing.assert_allclose(output_rtdist, output_rtdist2, rtol=1e-4)
-    
+
 
 def test_resetting_between_flavours(reltrans):
     energy = np.logspace(np.log10(0.1), np.log10(100), 501)
@@ -454,58 +454,3 @@ def test_strans_routines_grtrace_outputs(reltrans, assert_snapshot):
     assert_snapshot(re, name="re1", rtol=2e-4)
     assert_snapshot(taudo, name="taudo1", rtol=2e-4)
     assert_snapshot(pem, name="pem1", rtol=2e-4)
-
-
-def test_trace_observer_disk_single_photon(reltrans):
-    '''This test computes the ray tracing from the observer to the disk for a single geodesic'''
-    reltrans.reset()
-    aspin = 0.998
-    cos0  = np.cos(30.0/180.0 * np.pi)
-    sin0  = np.sqrt(1.0 - cos0**2)
-    dist  = 18000000.0
-    scal  = 1.0
-    alpha = 3.0 #totally random
-    beta  = 4.0 #totally random
-    #from the observer camera parameter to the Carter's constants of motion 
-    four_momentum, lambda_, q = reltrans.constants_of_motion(-alpha,-beta,dist,sin0,cos0,aspin,scal)
-    mudisk  = 0.0
-    r_max   = 1e8
-    r_min   = 0.0
-    #from the Carter's constant of motion to the affine parameter where the geodesic hit the disk
-    p_out = reltrans.p_disk_crossing(four_momentum,lambda_.value,q.value,sin0,cos0,aspin,dist,scal,mudisk,r_max,r_min)
-    #from the affine parameter and constant of motion to the interesting values
-    radi, mu, phi, time, sigma = reltrans.get_raytrace_coords(p_out,four_momentum,lambda_,q,sin0,cos0,aspin,dist,scal)
-    # print(f'FROM THE TESTS: radi {radi}, mu {mu}, phi {phi}, time {time}, sigma {sigma}')
-    assert radi.value  == pytest.approx(3.3090221511440556, rel=1e-4) 
-    assert mu.value    == pytest.approx(0.0, rel=1e-4) 
-    assert time.value  == pytest.approx(18000034.946610235, rel=1e-4) 
-    assert sigma.value == pytest.approx(18000000.171032075, rel=1e-4)
-
-
-def test_trace_source_disk_single_photon(reltrans):
-    '''This test computes the ray-tracing from the lamppost source to the disk for a single geodesic'''
-    reltrans.reset()
-    deltas = 40.0/180.0 * np.pi #180 degree out from kerrz
-    pr     = np.cos(deltas)           #cosdelta
-    pp     = np.sqrt( 1.0 - pr**2 )   #sindelta
-    pt     = 0.0
-    mus    = 1.0   #Position of source: mus=1 means on-axis
-    sins   = np.sqrt(1.0 - mus**2)   #sin of same angle
-    aspin  = 0.998
-    h      = 6.0
-    scal   = 1.0
-    #from the source paramter to the Carter's constants of motion
-    four_momentum, lambda_, q = reltrans.initial_photon(pr,pt,pp,sins,mus,aspin,h)
-    mudisk  = 0.0
-    r_max   = 300.0
-    r_min   = 1.3
-    #from the Carter's constant of motion to the affine parameter where the geodedic hit the disk
-    p_out = reltrans.p_disk_crossing(four_momentum,lambda_,q,sins,mus,aspin,h,
-          scal,mudisk,r_max,r_min)
-    #from the affine parameter and constant of motion to the interesting values
-    radi, mu, phi, time, sigma = reltrans.get_raytrace_coords(p_out,four_momentum,lambda_.value,q.value,sins,mus,aspin,h,scal)
-    # print(f'FROM THE TESTS: radi {radi}, mu {mu}, phi {phi}, time {time}, sigma {sigma}')
-    assert radi.value  == pytest.approx(2.9239091166396736, rel=1e-4) 
-    assert mu.value    == pytest.approx(0.0, rel=1e-4) 
-    assert time.value  == pytest.approx(10.567334777173707, rel=1e-4) 
-    assert sigma.value == pytest.approx(5.442883301224947, rel=1e-4)

--- a/test/test_raytracing.py
+++ b/test/test_raytracing.py
@@ -1,0 +1,58 @@
+import pytest
+import numpy as np
+from pyreltrans import DCP_Parameters, Dbl_Parameters, rtdist_Parameters
+
+
+def test_trace_observer_disk_single_photon(reltrans):
+    '''This test computes the ray tracing from the observer to the disk for a single geodesic'''
+    reltrans.reset()
+    aspin = 0.998
+    cos0  = np.cos(30.0/180.0 * np.pi)
+    sin0  = np.sqrt(1.0 - cos0**2)
+    dist  = 18000000.0
+    scal  = 1.0
+    alpha = 3.0 #totally random
+    beta  = 4.0 #totally random
+    #from the observer camera parameter to the Carter's constants of motion
+    four_momentum, lambda_, q = reltrans.constants_of_motion(-alpha,-beta,dist,sin0,cos0,aspin,scal)
+    mudisk  = 0.0
+    r_max   = 1e8
+    r_min   = 0.0
+    #from the Carter's constant of motion to the affine parameter where the geodesic hit the disk
+    p_out = reltrans.p_disk_crossing(four_momentum,lambda_.value,q.value,sin0,cos0,aspin,dist,scal,mudisk,r_max,r_min)
+    #from the affine parameter and constant of motion to the interesting values
+    radi, mu, phi, time, sigma = reltrans.get_raytrace_coords(p_out,four_momentum,lambda_,q,sin0,cos0,aspin,dist,scal)
+    # print(f'FROM THE TESTS: radi {radi}, mu {mu}, phi {phi}, time {time}, sigma {sigma}')
+    assert radi.value  == pytest.approx(3.3090221511440556, rel=1e-4)
+    assert mu.value    == pytest.approx(0.0, rel=1e-4)
+    assert time.value  == pytest.approx(18000034.946610235, rel=1e-4)
+    assert sigma.value == pytest.approx(18000000.171032075, rel=1e-4)
+
+
+def test_trace_source_disk_single_photon(reltrans):
+    '''This test computes the ray-tracing from the lamppost source to the disk for a single geodesic'''
+    reltrans.reset()
+    deltas = 40.0/180.0 * np.pi #180 degree out from kerrz
+    pr     = np.cos(deltas)           #cosdelta
+    pp     = np.sqrt( 1.0 - pr**2 )   #sindelta
+    pt     = 0.0
+    mus    = 1.0   #Position of source: mus=1 means on-axis
+    sins   = np.sqrt(1.0 - mus**2)   #sin of same angle
+    aspin  = 0.998
+    h      = 6.0
+    scal   = 1.0
+    #from the source paramter to the Carter's constants of motion
+    four_momentum, lambda_, q = reltrans.initial_photon(pr,pt,pp,sins,mus,aspin,h)
+    mudisk  = 0.0
+    r_max   = 300.0
+    r_min   = 1.3
+    #from the Carter's constant of motion to the affine parameter where the geodedic hit the disk
+    p_out = reltrans.p_disk_crossing(four_momentum,lambda_,q,sins,mus,aspin,h,
+          scal,mudisk,r_max,r_min)
+    #from the affine parameter and constant of motion to the interesting values
+    radi, mu, phi, time, sigma = reltrans.get_raytrace_coords(p_out,four_momentum,lambda_.value,q.value,sins,mus,aspin,h,scal)
+    # print(f'FROM THE TESTS: radi {radi}, mu {mu}, phi {phi}, time {time}, sigma {sigma}')
+    assert radi.value  == pytest.approx(2.9239091166396736, rel=1e-4)
+    assert mu.value    == pytest.approx(0.0, rel=1e-4)
+    assert time.value  == pytest.approx(10.567334777173707, rel=1e-4)
+    assert sigma.value == pytest.approx(5.442883301224947, rel=1e-4)


### PR DESCRIPTION
The test debug plotting functions are useful but that usefulness is impeded by needing to uncomment them one at a time, and then closing the windows that pop up. This PR introduces the `test/_plots` directory where failed tests are plotted and saved as images.

This is useful especially for the transition away from YNOGK, as we'll need to inspect all of the snapshots manually to make sure results are consistent.

By default, plots are only produced for failing tests, but can be produced for all tests by passing `--plot-always=True` when running `pytest`.

The plots are all approximately the same, with quite a few configuration options. Below is an example:

<img width="1000" height="600" alt="test_basic_invocation" src="https://github.com/user-attachments/assets/946dabdb-0088-4fd0-a64d-b69de7f99191" />

I tried to setup a system that would have the CI post these plots to the PR comments automatically, but it's tricky to do without having some place external to github where the images can be uploaded and hosted. So maybe in the future?