### PR TITLE
bug fix: Fixed post_process.f90

### DIFF
--- a/post_processor.f90
+++ b/post_processor.f90
@@ -239,7 +239,7 @@ function distance(Cp, nlp, xe_in, adensity_in, param)
     call arguments_check(config, model_args)
 
     if (config%firstcall) then
-        call init_fftw_allconv()
+        call init_fftw_allconv(.false.)
         config%firstcall = .false.
         config%needtrans = .true.
         config%needconv  = .true.
@@ -269,8 +269,9 @@ function distance(Cp, nlp, xe_in, adensity_in, param)
     call setup_arrays(config, arrays, model_args%nlp)
     
     ! reallocated frequency dependent arrays
-    call realloc_arrays(config, model_args, arrays, prev_nf)
+    call realloc_arrays(config, model_args, arrays, prev_nf, flosave, fhisave)
 
+    
     ! Note: the two different calls are because for the double lP we set the
     ! temperature from the coronal frame(s), but for the single
     ! LP we use the temperature in the observer frame

--- a/post_processor.f90
+++ b/post_processor.f90
@@ -123,9 +123,6 @@ subroutine post_processor(param,xe,adensity,chainmode,chainfile,newchainfile,  &
         if(status .ne. 0) stop 'Cannot determine No of rows'
         call ftgkyj(unit,'TFIELDS',columns,comment,status)
         if(status .ne. 0) stop 'Cannot determine No of columns'
-
-        steps = 100 !!!!!!!!!!!!!!!!!!!*******************
-
         
         !Copy chain file to new chain file
         status = 0
@@ -239,7 +236,7 @@ function distance(Cp, nlp, xe_in, adensity_in, param)
     call arguments_check(config, model_args)
 
     if (config%firstcall) then
-        call init_fftw_allconv(.false.)
+        call init_fftw_allconv(.true.)
         config%firstcall = .false.
         config%needtrans = .true.
         config%needconv  = .true.


### PR DESCRIPTION
Thanks for opening a PR!

## Checklist
- [ ] I have HEASOFT installed and compiled 
- [ ] I compiled reltrans
- [ ] I have run the test suite (pytest)

## Description of this PR
post_process.f90 had stopped working again. Some of the subroutine calls had been changed, meaning it was calling subroutines with the wrong number of arguments. Now fixed to call the subroutines properly. Once we get a python wrapper on this, it will be worth adding it to the test suite.

Instructions:
Ideally, your PR should entirely solve an issue, if it doesn't it should be justified here
This PR addresses issue #0 [put the issue number here]
Please describe what you have changed

## Anything important?

