### PR TITLE
simrelt: reset instrument files on each call

### DIFF
--- a/subroutines/common.f90
+++ b/subroutines/common.f90
@@ -138,7 +138,33 @@ contains
       ! a fresh start of the model
       global_config%firstcall = .true.
     end subroutine reset_reltrans
-  
+ 
+    subroutine reset_instrument_files() bind(C, name="reset_instrument_files")
+      ! De-allocate any and all instrument files
+      use telematrix
+      use telematrix2
+      if (allocated(En)) deallocate(En)
+      if (allocated(resp)) deallocate(resp)
+      if (allocated(ECHN)) deallocate(ECHN)
+      if (allocated(NGRP)) deallocate(NGRP)
+      if (allocated(FCHAN)) deallocate(FCHAN)
+      if (allocated(LCHAN)) deallocate(LCHAN)
+      if (allocated(NCHAN)) deallocate(NCHAN)
+      if (allocated(bkgcounts)) deallocate(bkgcounts)
+      if (allocated(bkgrate)) deallocate(bkgrate)
+      if (allocated(En2)) deallocate(En2)
+      if (allocated(resp2)) deallocate(resp2)
+      if (allocated(ECHN2)) deallocate(ECHN2)
+      if (allocated(NGRP2)) deallocate(NGRP2)
+      if (allocated(FCHAN2)) deallocate(FCHAN2)
+      if (allocated(LCHAN2)) deallocate(LCHAN2)
+      if (allocated(NCHAN2)) deallocate(NCHAN2)
+      needresp = .true.
+      needchans = .true.
+      needbkg = .true.
+      needresp2 = .true.
+      needchans2 = .true.
+    end subroutine reset_instrument_files
 
     ! Unwraps the arguments from a parameter array into `args`.
     subroutine unwrap_arguments(args, nlp, dset, params, cutoff_powerlaw)

--- a/wrappers.f90
+++ b/wrappers.f90
@@ -700,6 +700,7 @@ end subroutine simrtdist
 !-----------------------------------------------------------------------
 subroutine simrelt(ear, ne, param, ifl, photar)
   use telematrix
+  use common_types, only: reset_instrument_files
   implicit none
   integer :: ne, ifl, Cp, dset, i
   real    :: ear(0:ne), param(24), photar(ne), par(32)
@@ -720,6 +721,9 @@ subroutine simrelt(ear, ne, param, ifl, photar)
   data idum/-2851043/
   save idum
   character (len=200) command,flxlagfile,phalagfile,rsplagfile,lagfile,root
+  ! Reset instrument files lest they have changed
+  call reset_instrument_files()
+
 ! Settings
   Cp   = 2   !|Cp|=2 means nthcomp, Cp>1 means there is a density parameter     
   dset = 0   !dset=1 means distance is set, logxi is calculated internally


### PR DESCRIPTION
Technically not the most elegant solution, but it's good enough that it means you can use simrelt from Python with multiple instrument files, provided you change the environment variables as needed.

Makes comparing NewAthena and XMM simulations a bit more of a breeze.