### PR TITLE
One ring to rule them all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ ALL_RELTRANS_SOURCE_FILES = $(shell find $(ROOTDIR)/subroutines -name '*.f90')
 
 CFLAGS := -fno-omit-frame-pointer
 
-FFLAGS := -cpp \
-		  -fPIC -fno-second-underscore \
+FFLAGS := -cpp -DHAVE_INLINE \
+		  -fPIC -fno-automatic -fno-second-underscore \
 		  -fno-omit-frame-pointer \
 		  -I$(BUILD)/include \
 		  -I$(HEADAS_INCLUDE) \

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ ALL_RELTRANS_SOURCE_FILES = $(shell find $(ROOTDIR)/subroutines -name '*.f90')
 
 CFLAGS := -fno-omit-frame-pointer
 
-FFLAGS := -cpp -DHAVE_INLINE \
-		  -fPIC -fno-automatic -fno-second-underscore \
+FFLAGS := -cpp \
+		  -fPIC -fno-second-underscore \
 		  -fno-omit-frame-pointer \
 		  -I$(BUILD)/include \
 		  -I$(HEADAS_INCLUDE) \

--- a/pyreltrans/__init__.py
+++ b/pyreltrans/__init__.py
@@ -170,6 +170,52 @@ class DCP_Parameters:
     def to_numpy_array(self) -> np.ndarray:
         return np.array(dataclasses.astuple(self), dtype=np.float32)
 
+@dataclasses.dataclass
+class Ring_Parameters:
+    # The ring-corona radius (rg)
+    radius: float = 4.0
+    # The ring-corona opening angle (degrees)
+    angle: float = 45.0
+    # Spin
+    a: float = 0.998
+    # Inclination (degrees)
+    inc: float = 30.0
+    # Inner radius
+    rin: float = -1.0
+    # Outer radius
+    rout: float = 1e3
+    # Cosmological redshift
+    zcos: float = 0.0
+    # Photon index
+    gamma: float = 2.0
+    # logξ ionisation parameter
+    logxi: float = 3.0
+    # Iron abundance
+    afe: float = 1.0
+    # Electron abundance
+    lognep: float = 15.0
+    # Electron temperature in observer frame
+    kte: float = 60.0
+    # Hydrogen column density
+    nh: float = 0.0
+    # Boosting factor (ad-hoc normalisation)
+    boost: float = 1.0
+    # Black hole mass in solar units
+    mass: float = 4.6e7
+    # Lowest frequency in band
+    flo_hz: float = 0.0
+    # Highest frequency in band
+    fhi_hz: float = 0.0
+    # 1 -> Re, 2 -> Im, 3 -> modulus, 4 -> time lag, 5 -> folded modulus, 6 -> folded time lag
+    re_im: float = 1.0
+    del_a: float = 0.0
+    del_ab: float = 0.0
+    g: float = 0.0
+    telescope_response: float = 1.0
+
+    def to_numpy_array(self) -> np.ndarray:
+        return np.array(dataclasses.astuple(self), dtype=np.float32)
+
 
 @dataclasses.dataclass
 class Dbl_Parameters:
@@ -430,6 +476,14 @@ class Reltrans:
         """A wrapper around the XSPEC interface of rtdist"""
         return _wrap_call(
             self.lib_reltrans.tdrtdist_,
+            energy.astype(np.float32),
+            parameters.to_numpy_array(),
+        )
+
+    def reltransring(self, energy: np.ndarray, parameters: Ring_Parameters) -> np.ndarray:
+        """A wrapper around the XSPEC interface of the ring-like coronal model."""
+        return _wrap_call(
+            self.lib_reltrans.fbreltranswip_,
             energy.astype(np.float32),
             parameters.to_numpy_array(),
         )

--- a/pyreltrans/__init__.py
+++ b/pyreltrans/__init__.py
@@ -645,6 +645,58 @@ class Reltrans:
         )
         return (lensing_factor.value, cos_delta.value, time.value)
 
+    def get_impulse_response(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        self.lib_reltrans.response_get.argtypes = [
+            ct.POINTER(ct.c_void_p),  # ptr (output)
+            ct.POINTER(ct.c_void_p),  # eaxis_ptr (output)
+            ct.POINTER(ct.c_void_p),  # taxis_ptr (output)
+            ct.POINTER(ct.c_int),     # ne (output)
+            ct.POINTER(ct.c_int)      # nt (output)
+        ]
+        self.lib_reltrans.response_get.restype = None  # subroutine returns void
+
+        ptr = ct.c_void_p()
+        eaxis_ptr = ct.c_void_p()
+        taxis_ptr = ct.c_void_p()
+        ne = ct.c_int()
+        nt = ct.c_int()
+
+        # Call the Fortran subroutine
+        self.lib_reltrans.response_get(
+            ct.byref(ptr),
+            ct.byref(eaxis_ptr),
+            ct.byref(taxis_ptr),
+            ct.byref(ne),
+            ct.byref(nt)
+        )
+
+        # Extract dimensions
+        ne_val = ne.value
+        nt_val = nt.value
+
+        # Convert C pointers to NumPy arrays
+        response_array = np.ctypeslib.as_array(
+            ct.cast(ptr, ct.POINTER(ct.c_double)),
+            shape=(nt_val, ne_val),
+        ).T
+
+        energy_axis = np.ctypeslib.as_array(
+            ct.cast(eaxis_ptr, ct.POINTER(ct.c_double)),
+            shape=(ne_val,)
+        )
+
+        time_axis = np.ctypeslib.as_array(
+            ct.cast(taxis_ptr, ct.POINTER(ct.c_double)),
+            shape=(nt_val,)
+        )
+
+        # Return copies to avoid lifetime issues with Fortran memory
+        return (
+            time_axis.copy(),
+            energy_axis.copy(),
+            response_array.copy(),
+        )
+
 
 
 __all__ = [

--- a/subroutines/common.f90
+++ b/subroutines/common.f90
@@ -344,11 +344,11 @@ contains
     ! Initialise all of the configuration fields that can be derived after
     ! `read_environment_variables` has been called, and allocate the arrays
     ! in `arrays`
-    subroutine setup_arrays(config, arrays, nlp)
+    subroutine setup_arrays(config, model_args, arrays)
         use conv_mod, only: nex
         type(t_config), intent(inout) :: config
+        type(t_model_arguments), intent(in) :: model_args
         type(t_arrays), intent(inout) :: arrays
-        integer, intent(in) :: nlp
         integer :: i
 
         if (allocated(arrays%earx  )) deallocate(arrays%earx  )
@@ -360,8 +360,8 @@ contains
 
         if (allocated(arrays%contx    )) deallocate(arrays%contx    )
         if (allocated(arrays%contx_int)) deallocate(arrays%contx_int)
-        allocate(arrays%contx(nex,nlp))
-        allocate(arrays%contx_int(nlp))
+        allocate(arrays%contx(nex,model_args%nlp))
+        allocate(arrays%contx_int(model_args%nlp))
 
         config%dloge = log10(config%Emax / config%Emin) / float(nex)
 

--- a/subroutines/common.f90
+++ b/subroutines/common.f90
@@ -133,8 +133,22 @@ module common_types
         ! earx: internal energy grid array (0:nex)
         real, allocatable :: earx(:), ear(:), fix(:)
         real, allocatable :: ReGbar(:), ImGbar(:)
+
+        ! The continuum flux, `contx(num_energy_bins, num_lampposts)`.
         real, allocatable :: contx(:,:)
+
+        ! The continuum fluxes for the ring-like corona,
+        !
+        !     ring_continuums(num_energy_bins, num_azimuthal_points)
+        !
+        ! The ring-like corona stores a different continuum flux for each point
+        ! along the ring. It also uses `contx(:,1)` to store the average, as
+        ! that is still used for `xilimits` and various other ionisation-related
+        ! computations.
+        real, allocatable :: ring_continuums(:,:)
+
         double precision, allocatable :: contx_int(:)
+
         ! TRANSFER FUNCTIONS and Cross spectrum dynamic allocation + variables
         complex, dimension(:,:,:,:,:), allocatable :: ker_W0, ker_W1, ker_W2, ker_W3
         ! ker_W0(nlp,ne,nf,me,xe) Transfer function W0 - linear transfer function
@@ -363,6 +377,14 @@ contains
         allocate(arrays%contx(nex,model_args%nlp))
         allocate(arrays%contx_int(model_args%nlp))
 
+        if (model_args%ring_like) then
+            if (allocated(arrays%ring_continuums)) then
+                deallocate(arrays%ring_continuums)
+            end if
+            ! TODO: no hard code
+            allocate(arrays%ring_continuums(nex,50))
+        end if
+
         config%dloge = log10(config%Emax / config%Emin) / float(nex)
 
         ! populate the energy array
@@ -470,6 +492,14 @@ contains
 
             if (allocated(arrays%ImG)) deallocate(arrays%ImG)
             allocate(arrays%ImG(nex,config%nf))
+
+            if (model_args%ring_like) then
+                if (allocated(arrays%ring_continuums)) then
+                    deallocate(arrays%ring_continuums)
+                end if
+                ! TODO: no hard code
+                allocate(arrays%ring_continuums(nex,50))
+            end if
         end if
     end subroutine
 end module common_types

--- a/subroutines/common.f90
+++ b/subroutines/common.f90
@@ -45,6 +45,24 @@ module common_types
         ! The below are computed from the above
         ! The cosine angle
         double precision :: muobs
+
+        ! Use ring-like coronal model. Should future models get added, this
+        ! could be promoted to an enumeration of some description.
+        logical :: ring_like = .false.
+
+        ! Used only in the ring-like coronal model:
+        ! These obey that the (x, z) coordinates of the ring in the x-z plane
+        ! are:
+        !
+        !     x = ring_r * sin(ring_angle)
+        !     z = ring_r * cos(ring_angle)
+        !
+        ! The radial offset from the black hole origin to a point in the ring
+        ! (rg):
+        double precision :: ring_r = 0.0
+        ! The inclination angle (in radians) off of the spin axis at which the
+        ! ring is opened to.
+        double precision :: ring_angle = 0.0
     end type t_model_arguments
 
     type :: t_config
@@ -78,10 +96,6 @@ module common_types
         double precision :: rnmax = 300.d0, dlogf = 0.09
 
         real :: DeltaGamma = 0.01
-
-        ! Use ring-like coronal model. Should future models get added, this
-        ! could be promoted to an enumeration of some description.
-        logical :: ring_like = .false.
 
         ! Toggle whether to calculate the impulse response or not. Since the
         ! impulse response is not directly used in calculations, and must be
@@ -170,16 +184,11 @@ contains
 
     ! Unwraps the arguments from a parameter array into `args`.
     subroutine unwrap_arguments(args, nlp, dset, params, cutoff_powerlaw)
-        use rtconstants, only: parse_reim
-        double precision, parameter :: pi = acos(-1.d0)
+        use rtconstants, only: parse_reim, pi
         integer, intent(in) :: nlp, dset, cutoff_powerlaw
         real, target, intent(in) :: params(32)
         type(t_model_arguments), intent(out) :: args
         integer :: i
-        do i = 1,nlp
-            args%DelAB(i) = params(27 + (i - 1) * nlp)
-            args%g(i) = params(28 + (i - 1) * nlp)
-        end do
         if (dset .eq. 1) then
            args%Dkpc = params(9)
            args%logxi = 0.0
@@ -188,7 +197,27 @@ contains
         end if
         args%h(1) = dble(params(1))
         args%h(2) = dble(params(2))
-        args%nlp = nlp
+
+        ! Set the coronal model:
+        if (nlp == -1) then
+            args%nlp = 1
+            args%ring_like = .true.
+            ! Set the heights to zero to catch bugs, since this paramter wont be
+            ! used in the ring-like model.
+            args%h = 0.0
+            args%ring_r = dble(params(1))
+            ! Convert to radians:
+            args%ring_angle = dble(params(2)) * pi / 180.0d0
+        else
+            ! Standard n-many lampposts:
+            args%nlp = nlp
+        end if
+
+        do i = 1,args%nlp
+            args%DelAB(i) = params(27 + (i - 1) * args%nlp)
+            args%g(i) = params(28 + (i - 1) * args%nlp)
+        end do
+
         args%a = dble(params(3))
         args%inc = dble(params(4))
         args%muobs = cos(args%inc * pi / 180.d0)
@@ -243,15 +272,17 @@ contains
             write(*,*)"Warning! rin<ISCO! Set to ISCO"
             model_args%rin = config%rmin
         end if
-        do i=1,model_args%nlp
-            if (model_args%h(i) .lt. 0.d0) then
-                model_args%h(i) = abs(model_args%h(i)) * config%rh
-            end if
-            if (model_args%h(i) .lt. 1.5d0*config%rh)then
-                write(*,*)"Warning! h<1.5*rh! Set to 1.5*rh"
-                model_args%h(i) = 1.5d0 * config%rh
-            end if
-        end do
+        if (.not. model_args%ring_like) then
+            do i=1,model_args%nlp
+                if (model_args%h(i) .lt. 0.d0) then
+                    model_args%h(i) = abs(model_args%h(i)) * config%rh
+                end if
+                if (model_args%h(i) .lt. 1.5d0*config%rh)then
+                    write(*,*)"Warning! h<1.5*rh! Set to 1.5*rh"
+                    model_args%h(i) = 1.5d0 * config%rh
+                end if
+            end do
+        end if
     end subroutine arguments_check
 
     ! Read in environment variables that configure reltrans

--- a/subroutines/continuum/getcont.f90
+++ b/subroutines/continuum/getcont.f90
@@ -1,19 +1,18 @@
 !-----------------------------------------------------------------------
     subroutine getcont(Cp, earx, nex, Gamma, Cutoff_s, Cutoff_obs,             &
                        logxi, logne, zcos, contx)
-!!! Calculates continuum spectrum calling nthComp with the correct normalisation
-!!!based on the xillver spectrum 
-!!!  Arg:
-        !  earx: energy grid
-        !  nex: number of grid points
-        !  Gamma: continuum spectrum inclination
-        !  Cutoff_s: high energy cut-off or electron temperature (source frame)
-        !  Cutoff_obs: high energy cut-off or electron temperature (observer frame)
-        !  logxi: ionisation parameter
-        !  logne: density
-        !  zcos: host galaxy redshift
-        !  (output) contx: continuum spectrum 
-
+!> Calculates continuum spectrum calling nthComp with the correct normalisation
+!> based on the xillver spectrum
+!>   Arg:
+!> earx: energy grid
+!> nex: number of grid points
+!> Gamma: continuum spectrum inclination
+!> Cutoff_s: high energy cut-off or electron temperature (source frame)
+!> Cutoff_obs: high energy cut-off or electron temperature (observer frame)
+!> logxi: ionisation parameter
+!> logne: density
+!> zcos: host galaxy redshift
+!> (output) contx: continuum spectrum
 !> Derivation of renormalisation constant:
 !> First convert to incident flux in units of [keV/cm^2/s]
 !> contx = contx * 10**(logne + logxi) / (4.0 * pi) / ergsev
@@ -23,8 +22,7 @@
 !> contx = contx / Icomp
 !> The divide by xi and by ne/1e15
 !> contx = contx / (10**(logxi + logne - 15))
-      
-      use gr_continuum
+      use gr_continuum, only: gso
       implicit none
       integer, intent(in)           :: nex, Cp
       real   , intent(in)           :: earx(0:nex), Cutoff_s, Cutoff_obs, logxi, logne
@@ -71,7 +69,7 @@
          !have a flux of 1 (or norm within xspec) at 1keV. We need to undo that
          !catastrophic monstrosity.
          
-!The continuum needs to be renormalised according to the illuminating flux that was considered in xillver 
+!The continuum needs to be renormalised according to the illuminating flux that was considered in xillver
 !Plus we divide by a factor that depends on ionisation and density to agree with the first versions of reltrans
          do i = 1, nex
             E   = 0.5 * ( earx(i) + earx(i-1) )
@@ -103,4 +101,3 @@
          
       return
     end subroutine getcont
-!-----------------------------------------------------------------------

--- a/subroutines/continuum/init_cont.f90
+++ b/subroutines/continuum/init_cont.f90
@@ -4,6 +4,7 @@ subroutine init_cont(config, model_args, arrays, Cp_cont, fcons, dset)
     use dyn_gr
     use conv_mod
     use gr_continuum
+    use ring_corona, only: ring_calculate_continuum
     implicit none
     type(t_config)         , intent(in)      :: config
     type(t_model_arguments), intent(inout)   :: model_args
@@ -18,8 +19,16 @@ subroutine init_cont(config, model_args, arrays, Cp_cont, fcons, dset)
     
     Cutoff_s   = model_args%Cutoff_s
     Cutoff_obs = model_args%Cutoff_obs
-    
-    if (model_args%nlp .eq. 1) then
+
+    if (model_args%ring_like) then
+       ! TODO: check this for the ring corona. I copied it from the lamppost
+       ! case, but I'm not entirely sure what it does.
+       arrays%contx_int(1) = 1.
+       fcons = 0.0
+
+       call ring_calculate_continuum(config, model_args, arrays)
+
+    else if (model_args%nlp .eq. 1) then
        arrays%contx_int(1) = 1. !note: for a single LP we don't need to account for this factor in the ionisation profile, so it's defaulted to 1
 
        if( model_args%Cp .ge. 0 ) then

--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -309,7 +309,7 @@ subroutine genreltrans(Cp, dset, corona_config, ear, ne, param, ifl, photar)
     use telematrix2
     use rtconstants
     use xspec_interface
-    use kerrz, only: kerr_metric, krz_KerrMetric_init
+    use kerrz, only: kerr_metric, krz_KerrMetric_init, kerrz_init_threads
     implicit none
     ! Constants
     double precision, parameter :: rnmax = 300.d0, dlogf = 0.09 !This is a resolution parameter (base 10)
@@ -374,6 +374,15 @@ subroutine genreltrans(Cp, dset, corona_config, ear, ne, param, ifl, photar)
         ! Zero all of the saved parameters on the first call.
         paramsave = 0.0d0
         spinsav = -2.d0 !this is needed to force the run of the GRtrace routine
+
+        ! If we're computing the ring-like model on the fly, initialise the
+        ! kerrz threads.
+        if (model_args%ring_like) then
+            call kerrz_init_threads()
+            ! TODO: remove this later
+            print *, "WARNING: The ring-like model is being actively developed."
+            print *, "With any result or simulation: **do not** trust your eyes!"
+        end if
 
         ! finally, let the people know what they are witnessing!
         call print_header()

--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -310,6 +310,7 @@ subroutine genreltrans(Cp, dset, corona_config, ear, ne, param, ifl, photar)
     use rtconstants
     use xspec_interface
     use kerrz, only: kerr_metric, krz_KerrMetric_init, kerrz_init_threads
+    use ring_corona, only: ring_radial_gradients
     implicit none
     ! Constants
     double precision, parameter :: rnmax = 300.d0, dlogf = 0.09 !This is a resolution parameter (base 10)
@@ -437,9 +438,14 @@ subroutine genreltrans(Cp, dset, corona_config, ear, ne, param, ifl, photar)
 
     ! set up the continuum spectrum plus relative quantities (cutoff
     ! energies, lensing/gfactors, luminosity, etc)
+
     call init_cont(config, model_args, arrays, Cp_cont, fcons, dset)
     if (dset .eq. 0) then
-       call radfunctions_dens(config, model_args, arrays)
+        if (model_args%ring_like) then
+            call ring_radial_gradients(config, model_args, arrays)
+        else
+            call radfunctions_dens(config, model_args, arrays)
+        end if
     else
        call radfuncs_dist(config, model_args, fcons)
      end if

--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -273,7 +273,7 @@ contains
 end module m_genreltrans
 
 
-subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
+subroutine genreltrans(Cp, dset, corona_config, ear, ne, param, ifl, photar)
 ! All reltrans flavours are calculated in this subroutine.
 ! Cp and dset are the settings:
 ! |Cp|=1 means use cut-off power-law, |Cp|=2 means use nthcomp
@@ -315,7 +315,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
     double precision, parameter :: rnmax = 300.d0, dlogf = 0.09 !This is a resolution parameter (base 10)
     ! Args:
     integer, intent(inout) :: ifl
-    integer, intent(in) :: Cp, dset, ne, nlp
+    integer, intent(in) :: Cp, dset, ne, corona_config
     real, intent(inout) :: param(32)
     real, intent(out) :: photar(ne)
     ! Variables of the subroutine
@@ -346,7 +346,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
 
     config => global_config
 
-    call unwrap_arguments(model_args, nlp, dset, param, Cp)
+    call unwrap_arguments(model_args, corona_config, dset, param, Cp)
     call config_frequency(config, model_args)
     call arguments_check(config, model_args)
 
@@ -412,11 +412,11 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
     if (config%needtrans)then
        ! allocate lensing/reflection fraction arrays if necessary
        if (allocated(lens)) deallocate(lens)
-       allocate (lens(nlp))
+       allocate (lens(model_args%nlp))
        if (allocated(frobs)) deallocate(frobs)
-       allocate (frobs(nlp))
+       allocate (frobs(model_args%nlp))
        if (allocated(frrel)) deallocate(frrel)
-       allocate (frrel(nlp))
+       allocate (frrel(model_args%nlp))
        ! Calculate the Kernel for the given parameters
        call rtrans(config, model_args, arrays, dset, d, nex, frobs, frrel)
        ! print *, 'gso ', gso(1)
@@ -458,34 +458,35 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
     ! different subroutine
     if (model_args%ReIm .eq. 7) then
         ! tbd - implement zero cohernece in lag_freq
-        if (nlp .gt. 1 .and. model_args%beta_p .eq. 0.) then
+        if (model_args%nlp .gt. 1 .and. model_args%beta_p .eq. 0.) then
             call lag_freq_nocoh(nex, arrays%earx, config%nf, arrays%fix,       &
                  real(config%flo), real(config%fhi), config%Emin,              &
-                 config%Emax, nlp, arrays%contx, absorbx, real(tauso),         &
-                 real(gso), arrays%ReW0, arrays%ImW0, arrays%ReW1,             &
-                 arrays%ImW1, arrays%ReW2, arrays%ImW2, arrays%ReW3,           &
-                 arrays%ImW3, real(model_args%h), real(model_args%zcos),       &
-                 real(model_args%Gamma), real(model_args%eta),                 &
-                 model_args%boost, model_args%g, model_args%DelAB,             &
-                 config%ionvar, arrays%ReGbar, arrays%ImGbar)
+                 config%Emax, model_args%nlp, arrays%contx, absorbx,           &
+                 real(tauso), real(gso), arrays%ReW0, arrays%ImW0,             &
+                 arrays%ReW1, arrays%ImW1, arrays%ReW2, arrays%ImW2,           &
+                 arrays%ReW3, arrays%ImW3, real(model_args%h),                 &
+                 real(model_args%zcos), real(model_args%Gamma),                &
+                 real(model_args%eta), model_args%boost, model_args%g,         &
+                 model_args%DelAB, config%ionvar, arrays%ReGbar,               &
+                 arrays%ImGbar)
         else
             call lag_freq(nex, arrays%earx, config%nf, arrays%fix,             &
                  real(config%flo), real(config%fhi), config%Emin,              &
-                 config%Emax, nlp, arrays%contx, absorbx, real(tauso),         &
-                 real(gso), arrays%ReW0, arrays%ImW0, arrays%ReW1,             &
-                 arrays%ImW1, arrays%ReW2, arrays%ImW2, arrays%ReW3,           &
-                 arrays%ImW3, real(model_args%h), real(model_args%zcos),       &
-                 real(model_args%Gamma), real(model_args%eta),                 &
-                 model_args%beta_p, model_args%boost, model_args%g,            &
-                 model_args%DelAB, config%ionvar, arrays%ReGbar,               &
-                 arrays%ImGbar)
+                 config%Emax, model_args%nlp, arrays%contx, absorbx,           &
+                 real(tauso), real(gso), arrays%ReW0, arrays%ImW0,             &
+                 arrays%ReW1, arrays%ImW1, arrays%ReW2, arrays%ImW2,           &
+                 arrays%ReW3, arrays%ImW3, real(model_args%h),                 &
+                 real(model_args%zcos), real(model_args%Gamma),                &
+                 real(model_args%eta), model_args%beta_p, model_args%boost,    &
+                 model_args%g, model_args%DelAB, config%ionvar,                &
+                 arrays%ReGbar, arrays%ImGbar)
         end if
-    else if (nlp .gt. 1 .and. model_args%beta_p .eq. 0.) then
+    else if (model_args%nlp .gt. 1 .and. model_args%beta_p .eq. 0.) then
         call rawG(nex, arrays%earx, config%nf, real(config%flo),               &
-             real(config%fhi), nlp, arrays%contx, absorbx, real(tauso),        &
-             real(gso), arrays%ReW0, arrays%ImW0, arrays%ReW1, arrays%ImW1,    &
-             arrays%ReW2, arrays%ImW2, arrays%ReW3, arrays%ImW3,               &
-             real(model_args%h), real(model_args%zcos),                        &
+             real(config%fhi), model_args%nlp, arrays%contx, absorbx,          &
+             real(tauso), real(gso), arrays%ReW0, arrays%ImW0, arrays%ReW1,    &
+             arrays%ImW1, arrays%ReW2, arrays%ImW2, arrays%ReW3,               &
+             arrays%ImW3, real(model_args%h), real(model_args%zcos),           &
              real(model_args%Gamma), real(model_args%eta), model_args%boost,   &
              model_args%ReIm, model_args%g, model_args%DelAB, config%ionvar,   &
              config%DC, model_args%resp_matr, arrays%ReGrawa,                  &
@@ -524,7 +525,7 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
         ! parameters
         ! note: this must be done by rawG for two incoherent lamp posts, hence
         ! the skip below
-        if (nlp == 1 .or. model_args%beta_p .ne. 0.) then
+        if (model_args%nlp == 1 .or. model_args%beta_p .ne. 0.) then
             if (is_ref_folded(model_args%ReIm)) then
                 call propercross(nex, config%nf, arrays%earx,                  &
                      arrays%ReSrawa, arrays%ImSrawa, arrays%ReGrawa,           &
@@ -624,10 +625,10 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
     if (config%verbose .gt. 1 .and. abs(model_args%ReIm) .gt. 0 .and. model_args%ReIm .lt. 7) then
         if (config%DC .eq. 0 .and. model_args%beta_p .eq. 0) then
            call write_components(ne, ear, nex, arrays%earx, config%nf,         &
-                real(config%flo), real(config%fhi), nlp, arrays%contx,         &
-                absorbx, real(tauso), real(gso), arrays%ReW0, arrays%ImW0,     &
-                arrays%ReW1, arrays%ImW1, arrays%ReW2, arrays%ImW2,            &
-                arrays%ReW3, arrays%ImW3, real(model_args%h),                  &
+                real(config%flo), real(config%fhi), model_args%nlp,            &
+                arrays%contx, absorbx, real(tauso), real(gso), arrays%ReW0,    &
+                arrays%ImW0, arrays%ReW1, arrays%ImW1, arrays%ReW2,            &
+                arrays%ImW2, arrays%ReW3, arrays%ImW3, real(model_args%h),     &
                 real(model_args%zcos), real(model_args%Gamma),                 &
                 real(model_args%eta), model_args%beta_p, model_args%boost,     &
                 model_args%floHz, model_args%fhiHz, model_args%ReIm,           &
@@ -649,11 +650,11 @@ subroutine genreltrans(Cp, dset, nlp, ear, ne, param, ifl, photar)
         open (unit = 24, file = 'Output/Continuum_spec.dat', status = 'replace', action = 'write')
         do i = 1, nex
             dE = arrays%earx(i) - arrays%earx(i-1)
-            if (nlp .eq. 1) then
+            if (model_args%nlp .eq. 1) then
                 contx_temp = arrays%contx(i, 1)/dE
             else
                 contx_temp = 0.
-                do m = 1, nlp
+                do m = 1, model_args%nlp
                     contx_temp = contx_temp + arrays%contx(i, m)
                 end do
                 contx_temp = contx_temp/((1.+model_args%eta)*dE)

--- a/subroutines/genreltrans.f90
+++ b/subroutines/genreltrans.f90
@@ -361,7 +361,7 @@ subroutine genreltrans(Cp, dset, corona_config, ear, ne, param, ifl, photar)
         ! initialise environment and allocate all arrays
         call read_environment_variables(config)
         call setup_global_arrays(config, model_args%nlp)
-        call setup_arrays(config, arrays, model_args%nlp)
+        call setup_arrays(config, model_args, arrays)
 
         config%firstcall = .false.
         config%needtrans = .true.

--- a/subroutines/header.h
+++ b/subroutines/header.h
@@ -3,6 +3,8 @@ include 'subroutines/xspec_interface.f90'
 include 'subroutines/modules.f90'
 include 'subroutines/common.f90'
 
+include 'subroutines/ring.f90'
+
 include 'subroutines/continuum/getcont.f90'
 include 'subroutines/continuum/init_cont.f90'
 

--- a/subroutines/kerrz.f90
+++ b/subroutines/kerrz.f90
@@ -139,7 +139,7 @@ contains
         cont = LamppostContinuum(lensing_factor=1.0/continuum%dcosd_dcosth,    &
             cos_delta = cos(pi - continuum%angle_delta),                       &
             time = continuum%res%x_final%t, alpha = continuum%alpha,           &
-            beta = -continuum%beta)
+            beta = continuum%beta)
     end function trace_lensing
 
     subroutine stage_ring_emissivity(radius, theta)

--- a/subroutines/kerrz.f90
+++ b/subroutines/kerrz.f90
@@ -12,6 +12,17 @@ module kerrz
     ! TODO: move this to `t_config` or related.
     type(krz_KerrMetric) :: kerr_metric
 
+    ! This is a singleton that represents the thread pool that can be used to
+    ! parallelise kerrz specific operations.
+    type(krz_ThreadPool) :: kerrz_thread_pool
+
+    ! This is the emissivity cache that holds the last calculated emissivity
+    ! profile.
+    type(krz_EmissivityCache) :: kerrz_cache
+
+    ! This is used to track whether the threads have been initialised or not.
+    logical :: kerrz_ready = .false.
+
     type :: LamppostContinuum
         ! This is |∂cosδ / ∂cosθ|, the lensing factor.
         double precision :: lensing_factor
@@ -25,6 +36,38 @@ module kerrz
     end type LamppostContinuum
 
 contains
+
+    subroutine kerrz_init_threads()
+        !> Initialise the kerrz thread pool for parallel computations.
+        if (kerrz_ready) then
+            return
+        end if
+        ! The _8 means this is an INTEGER 8 literal in Fortran.
+        if (krz_ThreadPool_init(kerrz_thread_pool, 0_8)                        &
+            .ne. KRZ_RET_SUCCESS) then
+            write (*,*) "Failed to initialise thread pool"
+            stop 1
+        end if
+
+        ! Need a dummy metric to setup the emissivity cache.
+        kerr_metric = krz_KerrMetric_init(1.0d0, 0.998d0)
+        if (krz_EmissivityCache_init(kerrz_cache, 1000000_8)                    &
+            .ne. KRZ_RET_SUCCESS) then
+            write (*,*) "Failed to initialise emissivity cache"
+            stop 1
+        end if
+
+        kerrz_ready = .true.
+    end subroutine kerrz_init_threads
+
+    subroutine kerrz_deinit()
+        !> Cleanup the thread pool. This is not actually ever called in
+        !> reltrans, because reltrans never needs to terminate but I'm going to
+        !> leave this around as it may be useful in the future when reltrans
+        !> becomes more like a library.
+        call krz_ThreadPool_deinit(kerrz_thread_pool)
+        call krz_EmissivityCache_deinit(kerrz_cache)
+    end subroutine kerrz_deinit
 
     type(krz_TraceResult) function trace_impact_parameters(mu_obs, alpha, beta,&
         distance) result(res)
@@ -98,6 +141,32 @@ contains
             time = continuum%res%x_final%t, alpha = continuum%alpha,           &
             beta = -continuum%beta)
     end function trace_lensing
+
+    subroutine stage_ring_emissivity(radius, theta)
+        !> Calculate the emissivity profile for a ring-like corona with a
+        !> particular height and radius.
+        double precision, intent(in) :: radius, theta
+        double precision :: height, offset
+        type(krz_RingCorona) :: corona
+        height = radius * cos(theta)
+        offset = radius * sin(theta)
+        print *, "M: ", kerr_metric%M, "a: ", kerr_metric%a
+        print *, "height: ", height, "radius: ", offset
+        corona = krz_RingCorona(height, offset)
+        if (krz_emissivity_ring(kerrz_thread_pool, kerrz_cache, kerr_metric,   &
+            corona) .ne. KRZ_RET_SUCCESS) then
+            write (*,*) "Failed to calculate emissivity profile."
+            stop 1
+       end if
+        print *, "Success"
+    end subroutine stage_ring_emissivity
+
+    double precision function emissivity_at(r) result (em)
+        !> Interpolate from the emissivity cache the emissivity profile at a
+        !> particular radius on the accretion disc.
+        double precision, intent(in) :: r
+        em = krz_interpolate_emissivity(kerrz_cache, r)
+    end function emissivity_at
 
     ! These subroutines are defined for the test suite:
     subroutine test_kerrz_trace(spin, mu_obs, alpha, beta, t, r, theta, phi)   &

--- a/subroutines/kerrz.f90
+++ b/subroutines/kerrz.f90
@@ -20,6 +20,10 @@ module kerrz
     ! profile.
     type(krz_EmissivityCache) :: kerrz_cache
 
+    ! This is the continuum transfer function cache that holds the last
+    ! calculated ring-like corona transfer function.
+    type(krz_ContinuumRing) :: kerrz_continuum_cache
+
     ! This is used to track whether the threads have been initialised or not.
     logical :: kerrz_ready = .false.
 
@@ -157,16 +161,50 @@ contains
             corona) .ne. KRZ_RET_SUCCESS) then
             write (*,*) "Failed to calculate emissivity profile."
             stop 1
-       end if
+        end if
         print *, "Success"
     end subroutine stage_ring_emissivity
 
-    double precision function emissivity_at(r) result (em)
+    subroutine stage_ring_continuum(mu_obs, radius, theta)
+        !> Calculate the emissivity profile for a ring-like corona with a
+        !> particular height and radius.
+        double precision, intent(in) :: mu_obs, radius, theta
+        double precision :: height, offset
+        type(krz_RingCorona) :: corona
+        type(krz_FourVector) :: x_obs
+        height = radius * cos(theta)
+        offset = radius * sin(theta)
+        corona = krz_RingCorona(height, offset)
+
+        x_obs = krz_FourVector(t = 0.0d0, r = R_AT_INFINITY,                   &
+            th = acos(mu_obs), ph = 0.0d0)
+
+        ! TODO: remove this once kerrz has fully face-on implemented
+        if (abs(x_obs%th) < 1d-3) then
+            x_obs%th = 1d-3
+        end if
+
+        if (krz_traceContinuumRing(kerrz_continuum_cache, kerr_metric, x_obs,  &
+            corona) .ne. KRZ_RET_SUCCESS) then
+            write (*,*) "Failed to calculate continuum."
+            stop 1
+        end if
+        print *, "Success"
+    end subroutine stage_ring_continuum
+
+    type(krz_EmissivityTrace) function emissivity_values_at(r, phi) result (em)
         !> Interpolate from the emissivity cache the emissivity profile at a
         !> particular radius on the accretion disc.
-        double precision, intent(in) :: r
-        em = krz_interpolate_emissivity(kerrz_cache, r)
-    end function emissivity_at
+        double precision, intent(in) :: r, phi
+        em = krz_interpolate_emissivity(kerrz_cache, r, phi)
+    end function emissivity_values_at
+
+    type(krz_ContinuumRingPoint) function ring_continuum_at(phi) result (point)
+        !> Calculate the lensing factor and energyshift at a particular `phi`
+        !> coordinate along the ring.
+        double precision, intent(in) :: phi
+        point = krz_interpolate_continuum(kerrz_continuum_cache, phi)
+    end function ring_continuum_at
 
     ! These subroutines are defined for the test suite:
     subroutine test_kerrz_trace(spin, mu_obs, alpha, beta, t, r, theta, phi)   &

--- a/subroutines/rawG.f90
+++ b/subroutines/rawG.f90
@@ -1,3 +1,4 @@
+! TODO: remove `h` parameter from this function
 subroutine rawG(nex,earx,nf,flo,fhi,nlp,contx,absorbx,tauso,gso,ReW0,ImW0,ReW1,ImW1,ReW2,ImW2,ReW3,ImW3,h,z,Gamma,eta,&
                 boost,ReIm,g,DelAB,ionvar,DC,resp_matr,ReGraw,ImGraw)
                 

--- a/subroutines/rawS.f90
+++ b/subroutines/rawS.f90
@@ -13,6 +13,7 @@ subroutine sum_continuum_reflection_transfer_functions(config, model_args,     &
     !> Writes the output to `arrays%ReGraw` and `arrays%ImGraw`.
     use common_types, only: t_config, t_model_arguments, t_arrays
     use rtconstants, only: pi
+    use ring_corona, only: ring_cross_spectrum_with_continuum
     implicit none
     type(t_arrays), intent(inout) :: arrays
     type(t_config), intent(in) :: config
@@ -48,7 +49,11 @@ subroutine sum_continuum_reflection_transfer_functions(config, model_args,     &
         return
     end if
 
-    ! Calculating both the reflection and continuum components.
+    if (model_args%ring_like) then
+        ! Calculating both the reflection and continuum components:
+        call ring_cross_spectrum_with_continuum(config, model_args, arrays, nex)
+        return
+    end if
 
     ! Set up extra terms if second lamp post is presented:
     if( model_args%nlp > 1 ) then

--- a/subroutines/ring.f90
+++ b/subroutines/ring.f90
@@ -1,0 +1,227 @@
+! The radial profiles are currently all averaged from the illumination profiles.
+! This averaging is performed by the `ring_average` function below, and
+! populates the `dyn_gr` module arrays. This is to minimise the number of
+! changes that need to be make to reltrans at this time.
+!
+! The following functions are therefore not fully self-consistent in the time
+! resolved spectra:
+!
+!  - radial_profiles/logxiraw.f90
+!  - radial_profiles/xiraw.f90
+!  - radial_profiles/radfunctions_dens.f90
+!  - radial_profiles/radfunctions_dist.f90
+module ring_corona
+implicit none
+
+    ! The number of bins in coronal ring azimuth to sum over.
+    integer, parameter :: ring_nphi = 50
+    ! The weighting factor needed when summing over the different azimuthal
+    ! bins.
+    double precision, parameter :: ring_weight = 1.0d0 / float(ring_nphi)
+
+    ! This normalisation is determined so that the emissivity profiles that
+    ! kerrz calculates match what reltrans calculates using the internal method.
+    double precision, parameter :: ring_em_normalisation = 1.0d0 / (4d0 * acos(-1d0))
+
+contains
+
+    double precision function mean_r_annulus(rmax, rmin, n, i) result(mean_r)
+        double precision, intent(in) :: rmax, rmin
+        integer, intent(in) :: n, i
+        mean_r = (rmax/rmin)**(real(i-1) / real(n))
+        mean_r = mean_r + (rmax/rmin)**(real(i) / real(n))
+        mean_r = mean_r * rmin * 0.5
+    end function mean_r_annulus
+
+    subroutine ring_radial_gradients(config, model_args, arrays)
+        !> The ring-corona specific version of `radfuncs_dens`. The main
+        !> difference here is that the parameterisation cannot be in terms of
+        !> `cosd`, as that is not uniquely defined for each radius on the disc
+        !> for a ring like corona. Instead, as kerrz has calculated the
+        !> emissivity profile out to a large radial distance, those values are
+        !> used, and the Newtonian extrapolation is performed over disc radius.
+        !>
+        !> Side effects are all arrays in `radial_grids`:
+        !>
+        !>      logxir, gsdr, logner, dfer_arr
+        use common_types, only: t_config, t_model_arguments, t_arrays
+        use radial_grids, only: logxir, gsdr, logner, dfer_arr
+        use env_variables, only : adensity
+        use kerrz, only: krz_EmissivityTrace, emissivity_values_at,            &
+            krz_ContinuumRingPoint, ring_continuum_at
+        use rtconstants, only: pi
+        type(t_config), intent(in) :: config
+        type(t_model_arguments), intent(in) :: model_args
+        type(t_arrays), intent(in) :: arrays
+        double precision :: radius, total_ionisation, g_so, phi, ionisation
+        double precision :: g_sd_weighted, logxinorm, lognenorm, cos_incident_angle
+        type(krz_EmissivityTrace) :: source_to_disc
+        type(krz_ContinuumRingPoint) :: source_to_obs
+        integer :: i, phi_i
+        ! TODO: this is a function and should be in a module:
+        double precision :: mylogne, dgsofac, xiraw
+
+        do i = 1, config%xe
+            radius = mean_r_annulus(config%rnmax, model_args%rin, config%xe, i)
+            total_ionisation = 0.0
+            g_sd_weighted = 0.0
+
+            ! Calculate the raw-density (only matters for high density
+            ! reltransD)
+            logner(i) = adensity * mylogne(radius, model_args%rin)
+
+            ! Loop over every azimuthal bin of the ring-corona:
+            do phi_i = 1, ring_nphi
+                phi = 2 * pi * phi_i * ring_weight
+                source_to_disc = emissivity_values_at(radius, phi)
+                source_to_obs = ring_continuum_at(phi)
+                g_so = source_to_obs%energyshift
+
+                cos_incident_angle = cos(source_to_disc%local_theta)
+
+                ! TODO: double check this later, but I'm pretty sure the `xiraw`
+                ! function is just the emissivity profile.
+                ionisation = source_to_disc%em * ring_weight                   &
+                    * ring_em_normalisation
+
+                ! Correction to account for the radial dependence of incident
+                ! angle, and for the g factors
+                ! TODO: check where contx_int gets calculated.
+                ionisation = ionisation * arrays%contx_int(1)                  &
+                    * (g_so)**(model_args%Gamma - 2)      &
+                    / (sqrt(2.0) * cos_incident_angle)
+                total_ionisation = total_ionisation + ionisation
+
+                ! Accumulate the energyshift factor weighted by the ionisation:
+                g_sd_weighted = g_sd_weighted + ionisation * source_to_disc%g
+            end do
+
+            ! Now compute the azimuthally averaged values:
+            gsdr(i) = g_sd_weighted / total_ionisation
+
+            logxir(i) = log10(total_ionisation) - logner(i)
+        end do
+
+        ! Then we can determine the max and min ionisation, which allows it to
+        ! be renormalised:
+        logxinorm = maxval(logxir)
+        lognenorm = maxval(logner)
+        logxir = logxir - (logxinorm - dble(model_args%logxi))
+        logner = logner - (lognenorm - dble(model_args%lognep))
+
+    end subroutine ring_radial_gradients
+
+    subroutine ring_cross_spectrum_with_continuum(config, model_args, arrays,  &
+        nex)
+        ! The Fourier transform of the disc and continuum looks as follows:
+        !
+        !     s(nu, E) = A(nu) [ C(nu, E) + R(nu, E) ]
+        !
+        use common_types, only: t_config, t_model_arguments, t_arrays
+        use kerrz, only: krz_ContinuumRingPoint, ring_continuum_at
+        use rtconstants, only: pi
+        type(t_config), intent(in) :: config
+        type(t_model_arguments), intent(in) :: model_args
+        type(t_arrays), intent(inout) :: arrays
+        integer, intent(in) :: nex
+        type(krz_ContinuumRingPoint) :: source_to_obs
+        integer :: j, i, phi_i
+        double precision :: f, E, fac, phase, phi, phi_
+        complex :: W0, W1, W2, W3, Stemp, c_exp
+
+        do j=1,config%nf
+            f = config%flo *                                                   &
+                (config%fhi/config%flo)**((real(j)-0.5d0) / real(config%nf))
+            do i=1,nex
+                E = 0.5d0 * ( arrays%earx(i) + arrays%earx(i-1) )
+                ! Set up transfer functions
+                W0 = model_args%boost *                                        &
+                    cmplx(arrays%ReW0(1,i,j),arrays%ImW0(1,i,j))
+                W1 = (1-config%DC) * model_args%boost *                        &
+                    cmplx(arrays%ReW1(1,i,j),arrays%ImW1(1,i,j))
+                W2 = (1-config%DC) * model_args%boost *                        &
+                    cmplx(arrays%ReW2(1,i,j),arrays%ImW2(1,i,j))
+                W3 = config%ionvar * (1-config%DC) * model_args%boost *        &
+                    cmplx(arrays%ReW3(1,i,j),arrays%ImW3(1,i,j))
+
+                ! This represents the disc response:
+                Stemp = model_args%g(1) * (W1 + W2)
+                Stemp = Stemp + W0 + W3
+
+                arrays%ReSraw(i,j) = arrays%ReSraw(i,j) + real(Stemp)
+                arrays%ImSraw(i,j) = arrays%ImSraw(i,j) + aimag(Stemp)
+
+                ! Then sum the coronal contribution:
+                do phi_i = 1, ring_nphi
+                    phi = 2 * pi * phi_i * ring_weight
+                    source_to_obs = ring_continuum_at(phi)
+
+                    phase = 2 * pi * source_to_obs%delta_t * f
+                    c_exp = cmplx(cos(phase), sin(phase))
+                    c_exp = cmplx(1.0, 0.0)
+
+                    fac = log(source_to_obs%energyshift/((1d0+model_args%zcos)*E))
+
+                    Stemp = (1 + fac * model_args%g(1)) * c_exp *              &
+                        arrays%ring_continuums(i,phi_i) * ring_weight
+
+                    ! Separate into real/imaginary parts for compatibility with the
+                    ! rest of the code
+                    arrays%ReSraw(i,j) = arrays%ReSraw(i,j) + real(Stemp)
+                    arrays%ImSraw(i,j) = arrays%ImSraw(i,j) + aimag(Stemp)
+                 end do
+             end do
+        end do
+    end subroutine ring_cross_spectrum_with_continuum
+
+    subroutine ring_calculate_continuum(config, model_args, arrays)
+        use common_types, only: t_config, t_model_arguments, t_arrays
+        use kerrz, only: krz_ContinuumRingPoint, ring_continuum_at
+        use rtconstants, only: pi
+        use gr_continuum, only: gso, lens
+        use conv_mod, only: nex
+        type(t_config), intent(in) :: config
+        type(t_model_arguments), intent(inout) :: model_args
+        type(t_arrays), intent(inout) :: arrays
+        integer :: phi_i
+        double precision :: old_gso, aggregate_cutoff, phi
+        type(krz_ContinuumRingPoint) :: source_to_obs
+        ! Store the old `gso` value so it can be restored afterwards. This is
+        ! the 'average' source-to-disc energyshift factor.
+        old_gso = gso(1)
+
+        do phi_i = 1, ring_nphi
+            phi = 2 * pi * phi_i * ring_weight
+            source_to_obs = ring_continuum_at(phi)
+
+            ! TODO: make gso a parameter of getcont
+            ! gso(1) = source_to_obs%energyshift
+
+            model_args%Cutoff_obs = model_args%Cutoff_s * gso(1)               &
+                / real(1.d0 + model_args%zcos)
+
+            ! Sum the aggregate cutoff, so there is some effective 'seen'
+            ! cutoff that can be assigned back later.
+            aggregate_cutoff = aggregate_cutoff                                &
+                + model_args%Cutoff_obs * ring_weight
+
+            call getcont(2, arrays%earx, nex, model_args%Gamma,                &
+                model_args%Cutoff_s, model_args%Cutoff_obs, model_args%logxi,  &
+                model_args%lognep, model_args%zcos,                            &
+                arrays%ring_continuums(:,phi_i))
+
+            arrays%ring_continuums(:,phi_i) = lens(1)                          &
+                * (gso(1) / (real(1.d0 + model_args%zcos)))                    &
+                * arrays%ring_continuums(:,phi_i)
+
+            ! This aggregate is stil needed for the ionisation `xilimits`.
+            arrays%contx(:,1) = arrays%contx(:,1)                              &
+                + arrays%ring_continuums(:,phi_i) * ring_weight
+        end do
+
+        gso(1) = old_gso
+        ! model_args%Cutoff_obs = aggregate_cutoff
+    end subroutine ring_calculate_continuum
+
+end module ring_corona
+

--- a/subroutines/strans.f90
+++ b/subroutines/strans.f90
@@ -97,6 +97,7 @@ subroutine rtrans(config, model_args, arrays, dset, d, ne, frobs, frrel)
     use m_rtrans
     use raytracing, only: trace_disk_observer, getdcos, getlens
     use rtconstants, only: pi
+    use kerrz, only: stage_ring_emissivity
     implicit none
 
     type(t_config), intent(inout) :: config
@@ -213,6 +214,12 @@ subroutine rtrans(config, model_args, arrays, dset, d, ne, frobs, frrel)
         pnorm = 1.d0 / (4.d0 * pi)
     else
         pnorm = pnormer(args%model%b1, args%model%b2, args%model%qboost)
+    end if
+
+    ! Before we sum the impulse components, need to make sure the emissivity
+    ! profile has been calculated.
+    if (args%model%ring_like) then
+        call stage_ring_emissivity(args%model%ring_r, args%model%ring_angle)
     end if
 
     ! the only arguments that change here are .false., nro, nphi, rn, domega
@@ -345,7 +352,7 @@ subroutine sum_impulse_components(non_relativistic, r_length, phi_length,      &
             rbin = clamp_i(ceiling(log10(re / args%model%rin) /                &
                 args%dlogr), 1, args%conf%xe)
 
-            if (args%conf%ring_like) then
+            if (args%model%ring_like) then
                 call sum_ringlike_corona(i, non_relativistic, r_length,        &
                      phi_length, re, alpha, beta, taudo, g, r_grid, domega,    &
                      gbin, rbin, args)
@@ -378,6 +385,7 @@ subroutine sum_ringlike_corona(i, non_relativistic, r_length, phi_length,      &
     use rtconstants, only: pi
     use emissivities
     use impulseresponse, only: time_axis, response
+    use kerrz, only: emissivity_at
     use m_rtrans
     implicit none
 
@@ -400,21 +408,17 @@ subroutine sum_ringlike_corona(i, non_relativistic, r_length, phi_length,      &
 
     double precision :: tausd, tau, emissivity
 
-    ! this is a fixed number for now, representing the number of bins in azimuth
+    ! The number of bins in coronal ring azimuth to sum over:
+    ! TODO: make this part of the config structure
     integer, parameter :: r_nphi = 50
     double precision, parameter :: dphi = 2 * pi / float(r_nphi)
     ! index counting which phi bin we are currently considering
     integer :: phi_i
     double precision :: phi
 
-    if (args%model%nlp .ne. 1) then
-        print *, "panic: expected only one corona for ring-like corona"
-        error stop 1
-    end if
-
     ! Add to reflection fraction
-    args%frobs(1) = args%frobs(1) + 2.0 * g**3 * gsd * cosfac /                &
-        dareafac(re, args%model%a) * domega(i)
+    ! TODO: get kerrz to spit this out
+    args%frobs(1) = 1.0
 
     ! Calculate flux from pixel
     gsd = dglpfacthick(re, args%model%a, args%model%h(1), args%mudisk)
@@ -428,14 +432,23 @@ subroutine sum_ringlike_corona(i, non_relativistic, r_length, phi_length,      &
     mue = demang(args%model%a, args%model%muobs, re, alpha, beta)
     mubin = ceiling(mue * dble(args%conf%me))
 
-    ! loop over all azmithal bins
+    ! Loop over all azmithal bins. This is in effect looping over the azimuthal
+    ! coordinate of the ring, but is equivalently looping around the azimuthal
+    ! coordinate of the accretion disc.
     do phi_i = 1, r_nphi
         phi = phi_i * dphi
 
-        ! the source to disc time of the current azimuthal bin
-        call get_emissivity_time(re, phi, emissivity, tausd)
-        ! normalise
+        ! TODO: the source to disc time of the current azimuthal bin
+        tausd = 0.0
+        emissivity = emissivity_at(re)
+
+        ! Normalise
         emissivity = emissivity / float(r_nphi)
+
+        ! TODO: for the ring-like corona, the source-to-disc time can be
+        ! deferred to be part of the continuum transfer function. I leave the
+        ! below for now so that I can check whether the rest of the modified
+        ! code is working.
 
         if (non_relativistic) then
             ! TODO: for the non-relativistic case, can likely also consider the

--- a/subroutines/strans.f90
+++ b/subroutines/strans.f90
@@ -97,7 +97,9 @@ subroutine rtrans(config, model_args, arrays, dset, d, ne, frobs, frrel)
     use m_rtrans
     use raytracing, only: trace_disk_observer, getdcos, getlens
     use rtconstants, only: pi
-    use kerrz, only: stage_ring_emissivity
+    use kerrz, only: stage_ring_emissivity, krz_ContinuumRingPoint,            &
+        ring_continuum_at, stage_ring_continuum
+    use ring_corona, only: ring_nphi, ring_weight
     implicit none
 
     type(t_config), intent(inout) :: config
@@ -123,7 +125,13 @@ subroutine rtrans(config, model_args, arrays, dset, d, ne, frobs, frrel)
     double precision :: dFe(model_args%nlp)
     double precision pnormer, pfunc_raw, ang_fac
     double precision rnn(config%nro), domegan(config%nro)
+    double precision :: observed_bolometric_flux
     logical dotrace
+
+    integer :: phi_i
+    double precision :: phi, lensing_factor
+
+    type(krz_ContinuumRingPoint) :: direct
 
     ! Setup the output arrays
     call bind_arguments(args, config, model_args, arrays, frobs, dFe, fi, ne)
@@ -145,8 +153,39 @@ subroutine rtrans(config, model_args, arrays, dset, d, ne, frobs, frrel)
     !set up saving the impulse response function if user desires
     !note: the ideal parameters to plot the transfer function are nro~=7000,nphi~=7000,nt~=2e9,nex~=2e10
 
-    !get the GR ray-tracing CONTINUUM parameters which are stored in the module gr_continuum
-    if (args%model%nlp .eq. 1) then
+    ! Get the GR ray-tracing CONTINUUM parameters which are stored in the module
+    ! gr_continuum
+    if (args%model%ring_like) then
+        call stage_ring_continuum(args%model%muobs, args%model%ring_r,         &
+            args%model%ring_angle)
+
+        ! Average the g_so. This is done because so many parts of the code
+        ! expect there to be a single unique g_so, for e.g. determining the
+        ! xilimits. This is technically a big oversimplification, especially for
+        ! timing quantities, but it's a start.
+        !
+        ! We also need to calculate the bolometric flux of the observed spectrum
+        ! for the reflection fraction calculation. This can be done at the same
+        ! time, and used as the denominator against the reflected flux later.
+        !
+        ! After this, lens(1) stores the average lensing factor.
+        !             gso(1) stores the average energyshift.
+        !             tauso(1) stores the average source-to-observer time.
+        observed_bolometric_flux = 0.0
+        lens(1) = 0.0
+        gso(1) = 0.0
+        tauso(1) = 0.0
+        do phi_i = 1, ring_nphi
+            phi = 2 * pi * phi_i * ring_weight
+            direct = ring_continuum_at(phi)
+            observed_bolometric_flux = observed_bolometric_flux +              &
+                direct%dcosd_dcosth * direct%energyshift * ring_weight
+            lens(1) = lens(1) + direct%dcosd_dcosth * ring_weight
+            gso(1) = gso(1) + direct%energyshift * ring_weight
+            tauso(1) = tauso(1) + direct%delta_t * ring_weight
+        end do
+
+    else if (args%model%nlp .eq. 1) then
        gso(1) = real(dgsofac(args%model%a, args%model%h(1)))
        call getlens(args%model%a, args%model%h(1), args%model%muobs,           &
             lens(1), tauso(1), cosdelta_obs(1))
@@ -204,22 +243,21 @@ subroutine rtrans(config, model_args, arrays, dset, d, ne, frobs, frrel)
     !initialize radius grid, angles, and transfer functions
     sin0 = sqrt(1.0-args%model%muobs**2)
 
-    ! Calculate dcos/dr and time lags vs r for the lamppost model
-    call getdcos(args%model%a, args%model%h, args%mudisk, ndelta,              &
-         args%model%nlp, args%model%rout, npts, rlp, dcosdr, tlp, cosd,        &
-         cosdout)
+    if (args%model%ring_like) then
+        ! Calculate the disc illumination for the ring-like corona:
+        call stage_ring_emissivity(args%model%ring_r, args%model%ring_angle)
+    else
+        ! Calculate dcos/dr and time lags vs r for the lamppost model
+        call getdcos(args%model%a, args%model%h, args%mudisk, ndelta,          &
+             args%model%nlp, args%model%rout, npts, rlp, dcosdr, tlp, cosd,    &
+             cosdout)
+     end if
 
     ! set continuum normalisations depending on model flavour
     if (dset .eq. 0)then
         pnorm = 1.d0 / (4.d0 * pi)
     else
         pnorm = pnormer(args%model%b1, args%model%b2, args%model%qboost)
-    end if
-
-    ! Before we sum the impulse components, need to make sure the emissivity
-    ! profile has been calculated.
-    if (args%model%ring_like) then
-        call stage_ring_emissivity(args%model%ring_r, args%model%ring_angle)
     end if
 
     ! the only arguments that change here are .false., nro, nphi, rn, domega
@@ -230,19 +268,25 @@ subroutine rtrans(config, model_args, arrays, dset, d, ne, frobs, frrel)
     call sum_impulse_components(.true., args%conf%nron, args%conf%nphin,       &
          rnn, domegan, args)
 
-    do m = 1, args%model%nlp
-        ! Calculate 4pi p(theta0,phi0) = ang_fac
-        ang_fac = 4.d0 * pi * pnorm * pfunc_raw(-cosdelta_obs(m),              &
-            args%model%b1, args%model%b2, args%model%qboost)
-        ! Adjust the lensing factor (easiest way to keep track)
-        lens(m) = lens(m) * ang_fac
-        ! Calculate the relxill reflection fraction for one columncosdout
-        frrel(m) = sysfref(args%model%rin, rlp(:, m), cosd(:, m), ndelta,      &
-            cosdout(m))
-        !Finish calculation of observer's reflection fraction
-        args%frobs(m) = args%frobs(m) / dgsofac(args%model%a,                  &
-            args%model%h(m)) / lens(m)
-    end do
+    if (args%model%ring_like) then
+
+        ! This is now the ratio of reflected / observed
+        args%frobs(1) = args%frobs(1) / observed_bolometric_flux
+    else
+        do m = 1, args%model%nlp
+            ! Calculate 4pi p(theta0,phi0) = ang_fac
+            ang_fac = 4.d0 * pi * pnorm * pfunc_raw(-cosdelta_obs(m),          &
+                args%model%b1, args%model%b2, args%model%qboost)
+            ! Adjust the lensing factor (easiest way to keep track)
+            lens(m) = lens(m) * ang_fac
+            ! Calculate the relxill reflection fraction for one columncosdout
+            frrel(m) = sysfref(args%model%rin, rlp(:, m), cosd(:, m), ndelta,  &
+                cosdout(m))
+            !Finish calculation of observer's reflection fraction
+            args%frobs(m) = args%frobs(m) / dgsofac(args%model%a,              &
+                args%model%h(m)) / lens(m)
+        end do
+    end if
 
     if (args%conf%calculate_impulse_response) then
         ! Deal with edge effects
@@ -270,6 +314,7 @@ subroutine sum_impulse_components(non_relativistic, r_length, phi_length,      &
     use rtconstants, only: pi
     use emissivities
     use m_rtrans
+    use ring_corona, only: ring_nphi, ring_weight
     implicit none
     logical, intent(in) :: non_relativistic
 
@@ -303,9 +348,6 @@ subroutine sum_impulse_components(non_relativistic, r_length, phi_length,      &
     ! transfer function/convolution kernel in energy (gbin), frequency (fbin),
     ! emission angle (mubin), disk radial
     ! bin (rbin) from the m-th/nl-th lamp post
-
-    ! TODO: for ring-like corona, pre-load the correct time-dependent emissivity
-    ! profile here, before the loop over observer coordinates
 
     disc_seen = .false.
     do ri = 1, r_length
@@ -385,8 +427,9 @@ subroutine sum_ringlike_corona(i, non_relativistic, r_length, phi_length,      &
     use rtconstants, only: pi
     use emissivities
     use impulseresponse, only: time_axis, response
-    use kerrz, only: emissivity_at
+    use kerrz, only: krz_EmissivityTrace, emissivity_values_at
     use m_rtrans
+    use ring_corona, only: ring_nphi, ring_weight, ring_em_normalisation
     implicit none
 
     logical, intent(in) :: non_relativistic
@@ -408,20 +451,10 @@ subroutine sum_ringlike_corona(i, non_relativistic, r_length, phi_length,      &
 
     double precision :: tausd, tau, emissivity
 
-    ! The number of bins in coronal ring azimuth to sum over:
-    ! TODO: make this part of the config structure
-    integer, parameter :: r_nphi = 50
-    double precision, parameter :: dphi = 2 * pi / float(r_nphi)
     ! index counting which phi bin we are currently considering
     integer :: phi_i
-    double precision :: phi
-
-    ! Add to reflection fraction
-    ! TODO: get kerrz to spit this out
-    args%frobs(1) = 1.0
-
-    ! Calculate flux from pixel
-    gsd = dglpfacthick(re, args%model%a, args%model%h(1), args%mudisk)
+    double precision :: phi, lensing_factor
+    type(krz_EmissivityTrace) :: em_values
 
     normfac = real((g/(1.d0+args%model%zcos))**(2.+args%model%Gamma)*domega(i))
 
@@ -432,33 +465,44 @@ subroutine sum_ringlike_corona(i, non_relativistic, r_length, phi_length,      &
     mue = demang(args%model%a, args%model%muobs, re, alpha, beta)
     mubin = ceiling(mue * dble(args%conf%me))
 
-    ! Loop over all azmithal bins. This is in effect looping over the azimuthal
-    ! coordinate of the ring, but is equivalently looping around the azimuthal
-    ! coordinate of the accretion disc.
-    do phi_i = 1, r_nphi
-        phi = phi_i * dphi
+    ! Loop over all azmithal bins of the accretion disc.
+    do phi_i = 1, ring_nphi
+        phi = 2 * pi * phi_i * ring_weight
 
-        ! TODO: the source to disc time of the current azimuthal bin
-        tausd = 0.0
-        emissivity = emissivity_at(re)
+        ! Get the `tausd`, `emissivity` and `g_sd` energyshifts for the
+        ! ring-like corona. The `re` and `phi` here are both coordinates on the
+        ! accretion disc.
+        em_values = emissivity_values_at(re, phi)
+        tausd = em_values%t
+        emissivity = em_values%em * ring_weight * ring_em_normalisation
+        gsd = em_values%g
 
-        ! Normalise
-        emissivity = emissivity / float(r_nphi)
+        ! TODO: remove me once interpolations at the edges of the phi domain are
+        ! fixed.
+        if (emissivity == 0) then
+            cycle
+        end if
+
+        ! Add to reflection fraction:
+        ! This is Ingram et al. 2019 Equation (31), using the emissivity
+        ! expression and multiplying by the gsd factors to ensure the bolometric
+        ! intensity division is correct.
+        args%frobs(1) = args%frobs(1) + 4.0 * g**3 * emissivity *              &
+            gsd**(1 - args%model%Gamma) * domega(i)
 
         ! TODO: for the ring-like corona, the source-to-disc time can be
         ! deferred to be part of the continuum transfer function. I leave the
         ! below for now so that I can check whether the rest of the modified
         ! code is working.
-
         if (non_relativistic) then
             ! TODO: for the non-relativistic case, can likely also consider the
             ! corona to be a lamppost, since the spread of time values will be
             ! small, likely of order the size of the ring
             ! - this should be checked, else a full non-relatvistic version that
             !   loops over each azimuth used
-            tau = sqrt(re**2 + (args%model%h(1) - args%model%honr *            &
+            tau = sqrt(re**2 + (args%model%ring_r - args%model%honr *          &
                 re)**2) - re * (sin0 * sindisk * cos(phie) + args%model%muobs  &
-                * args%mudisk) + args%model%h(1) * args%model%muobs
+                * args%mudisk) + args%model%ring_r * args%model%muobs
             tau = (1.d0+args%model%zcos)*tau
         else
             tau = (1.d0 + args%model%zcos) * (tausd + taudo - tauso(1))

--- a/utils/cli.c
+++ b/utils/cli.c
@@ -17,6 +17,7 @@ float time_difference(struct timespec start, struct timespec end) {
 // either way, forward declare this as an extern, and let it be the linker's
 // problem
 extern void tdreltransdcp_(float *, int *, float *, int *, float *);
+extern void fbreltranswip_(float *, int *, float *, int *, float *);
 
 #define LOG_ERR(...)                                                           \
   fprintf(stderr, "ERR  : " __VA_ARGS__);                                      \
@@ -47,6 +48,57 @@ typedef struct reltrans_dcp_parameters {
 RT_DCP_Params default_parameters() {
   RT_DCP_Params params = {
       .h = 6.0,
+      .a = 0.998,
+      .inc = 30.0,
+      .rin = -1.0,
+      .rout = 1e3,
+      .zcos = 0.0,
+      .gamma = 2.0,
+      .logxi = 3.0,
+      .afe = 1.0,
+      .lognep = 15,
+      .kte = 60.0,
+      .nh = 0.0,
+      .boost = 1.0,
+      .mass = 4.6e7,
+      .flo_hz = 0.0,
+      .fhi_hz = 0.0,
+      .re_im = 1.0,
+      .del_a = 0.0,
+      .del_ab = 0.0,
+      .g = 0.0,
+      .telescope_response = 1,
+  };
+  return params;
+}
+
+typedef struct reltrans_ring_parameters {
+  float r,    // ring radius (rg)
+      th,     // ring opening angle (degrees)
+      a,      // spin
+      inc,    // inclination
+      rin,    // inner radius
+      rout,   // outer radius
+      zcos,   // cosmological redshift
+      gamma,  // photon index
+      logxi,  // logξ ionisation parameter
+      afe,    // iron abundance
+      lognep, // electron abundance (?)
+      kte,    // electron temperature in observer frame
+      nh,     // hydrogen column density
+      boost,  // boosting factor (ad-hoc normalisation)
+      mass,   // black hole mass in solar units
+      flo_hz, // lowest frequency in band
+      fhi_hz, // highest frequency in band
+      re_im,  // 1 -> Re, 2 -> Im, 3 -> modulus, 4 -> time lag, 5 -> folded
+              // modulus, 6 -> folded time lag
+      del_a, del_ab, g, telescope_response;
+} RT_Ring_Params;
+
+RT_Ring_Params default_ring_parameters() {
+  RT_Ring_Params params = {
+      .r = 4.0,
+      .th = 30.0,
       .a = 0.998,
       .inc = 30.0,
       .rin = -1.0,
@@ -108,11 +160,13 @@ int main() {
     return 1;
   }
 
-  RT_DCP_Params params = default_parameters();
-  params.re_im = 5.0;
-  params.mass = 10.0;
-  params.flo_hz = 0.122;
-  params.fhi_hz = 1.024;
+  // RT_DCP_Params params = default_parameters();
+  RT_Ring_Params params = default_ring_parameters();
+
+  // params.re_im = 5.0;
+  // params.mass = 10.0;
+  // params.flo_hz = 0.122;
+  // params.fhi_hz = 1.024;
 
   // logarithmic energy grid
   for (int i = 0; i < e_num; ++i) {
@@ -125,9 +179,10 @@ int main() {
   int ifl = 1;
   e_num -= 1;
   // Run once to load everything in
-  tdreltransdcp_(energy, &e_num, (float *)&params, &ifl, output);
+  // tdreltransdcp_(energy, &e_num, (float *)&params, &ifl, output);
+  fbreltranswip_(energy, &e_num, (float *)&params, &ifl, output);
 
-  size_t num_trials = 20;
+  size_t num_trials = 1;
 
   float total_time = 0;
   float *times_millis = malloc(sizeof(float) * num_trials);
@@ -146,7 +201,8 @@ int main() {
     clock_gettime(CLOCK_MONOTONIC, &now);
 
     int ifl = 1;
-    tdreltransdcp_(energy, &e_num, (float *)&params, &ifl, output);
+    // tdreltransdcp_(energy, &e_num, (float *)&params, &ifl, output);
+    fbreltranswip_(energy, &e_num, (float *)&params, &ifl, output);
 
     clock_gettime(CLOCK_MONOTONIC, &end);
     // Convert nano-seconds to mili-seconds.

--- a/wrappers.f90
+++ b/wrappers.f90
@@ -68,6 +68,56 @@ subroutine tdreltransDCp(ear, ne, param, ifl, photar)
 end subroutine tdreltransDCp
 !-----------------------------------------------------------------------
 
+!-----------------------------------------------------------------------
+subroutine fbreltransWIp(ear, ne, param, ifl, photar)
+  !> This is Fergus's (fb) reltrans WIp (work in progress) model. It will
+  !> eventually become the ring-like model.
+  implicit none
+  integer, parameter :: corona_config = -1 ! Use ring-like corona.
+  integer :: ne, ifl, Cp, dset
+  real    :: ear(0:ne), param(22), photar(ne), par(32)
+! Settings
+  Cp   = 2   !|Cp|=2 means nthcomp, Cp>1 means there is a density parameter
+  dset = 0   !dset=0 means distance is not set, logxi set instead
+! Transfer to general parameter array
+  par(1)  = param(1)         !r offset of the ring
+  par(2)  = param(2)         !inclination angle of the ring
+  par(3)  = param(3)         !a
+  par(4)  = param(4)         !inc
+  par(5)  = param(5)         !rin
+  par(6)  = param(6)         !rout
+  par(7)  = param(7)         !zcos
+  par(8)  = param(8)         !Gamma
+  par(9)  = param(9)         !logxi
+  par(10) = param(10)        !Afe
+  par(11) = param(11)        !lognep
+  par(12) = param(12)        !kTe
+  par(13) = 0.               ! not used
+  par(14) = 0.               ! not used
+  par(15) = 0.               ! not used
+  par(16) = param(13)        !Nh
+  par(17) = param(14)        !boost
+  par(18) = 1.0              !qboost
+  par(19) = param(15)        !Mass
+  par(20) = 0.0              ! not used
+  par(21) = 0.0              ! not used
+  par(22) = 0.0              ! not used
+  par(23) = param(16)        !floHz
+  par(24) = param(17)        !fhiHz
+  par(25) = param(18)        !ReIm
+  par(26) = param(19)        !DelA
+  par(27) = param(20)        !DelAB
+  par(28) = param(21)        !g
+  par(29) = 0.               ! not used
+  par(30) = 0.               ! not used
+  par(31) = 1.0              !Anorm
+  par(32) = param(22)        !telescope response
+! Call general code
+  call genreltrans(Cp, dset, corona_config, ear, ne, par, ifl, photar)  
+  return
+end subroutine fbreltransWIp
+!-----------------------------------------------------------------------
+
 
 !-----------------------------------------------------------------------
 subroutine tdreltransPL(ear, ne, param, ifl, photar)


### PR DESCRIPTION
The intial pass of implementing the ring-like corona is now complete!

What it models:
- Full time-dependent emissivity profile from the extended corona.
- Full time- and energy-resolved continuum profile, accounting for the various energyshift factors $g_\text{so}$ from different parts of the ring and their time delays.
- Complete agreement with the time-averaged and lag-energy spectrum of a lamppost corona when the ring opening angle is set to 0.1 degrees.

What it does not yet model:
- Time-variable ionisation, other than through the linear term in the transfer function. This is treated as with the double lamppost where a summed average along the ring is computed for the ionisation profile on the disc.
- Time-variable incident illumination angle. This is, similarly to the ionisation, averaged over time / each point along the ring.
- The Newtonian extension beyond 300 rg in impact parameter space with an actual ring corona. This calculation still uses a lamppost at the equivalent offset, but that can easily be ammended later.

This required #182 to be merged first, since it relies on some new interfaces in kerrz.

It also currently has a hard-coded co-rotating velocity profile, but I plan to add a velocity parameter where 0 would be locally-non rotating (i.e. as close to stationary as is physically meaningful), and 1 is fully co-rotating with the disc, such that a gradient can be applied between them. But I think it's better to do this incrementally with many small PRs than all at once.

Then kerrz is, and I know I say so myself, doing a very good job here, as it calculates all of the lensing factors and energy shifts taking the velocity into account and the various aberration / boosting effects of the frame. This would have been a very difficult calculation to do with anything other than maybe Gradus.jl, but kerrz sails through it.
